### PR TITLE
Initial

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,15 @@
 root = true
 
 [*]
+end_of_line = lf
+insert_final_newline = true
 charset = utf-8
+
+[*.gd]
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+
+[*.tscn]
+indent_style = space
+indent_size = 2

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,53 @@
+The repository is a Godot 4 project implementing a Scrabble-like word game (Wordatro).
+
+Quick context & goals
+- Primary runtime: Godot 4 (scripts use Node2D, Sprite2D, @onready). Open the project in the Godot editor and run the main scene `res://scenes/main/Main.tscn` to reproduce behavior.
+- Purpose of this file: give AI coding agents the essential, project-specific knowledge to make productive edits quickly.
+
+Core architecture (high level)
+- Autoload singletons: `autoload/event_bus.gd`, `autoload/game_manager.gd`, `autoload/tile_bag.gd`. Use `EventBus` signals to decouple subsystems (example signals: `tile_placed`, `turn_started`, `tiles_drawn`, `score_updated`).
+- Data models live under `scripts/core/`:
+  - `tile_model.gd` (class_name TileModel) — tile data object used across UI and logic.
+  - `board_model.gd` — 15x15 grid, `place_tile()` and `get_grid_state()` are authoritative board state.
+  - `word_checker.gd` — wraps the dictionary loader and exposes `is_valid_word()`.
+- Game logic under `scripts/logic/`:
+  - `turn_manager.gd` — turn lifecycle and counters.
+  - `word_finder.gd` — scans grid rows/columns and returns found words with start/end positions.
+  - `scoring.gd` — composes scoring via registered FuncRef rules; basic rule sums tile values.
+
+Key patterns & conventions (concrete examples)
+- Signal-first communication: components rarely call each other directly; instead emit/listen via `EventBus`.
+  - Example: `GameManager` connects to `EventBus.tile_placed` and updates `BoardModel` and score.
+  - Example: `Rack` connects to `TileBag.tiles_drawn` to instantiate tile scenes.
+- Preload/instance model: many systems use `preload("res://...").new()` to create helper objects (see `Main.gd` and `scoring.gd`). Preserve this pattern when adding new helper objects.
+- Data file: dictionary is `res://data/english_words.txt`. `scripts/util/dictionary_loader.gd` loads it into a Dictionary (hash) for O(1) lookups. Keep this path and loader usage when changing validation logic.
+- Visual/scene conventions: scene files live under `scenes/` and are instantiated by scripts (e.g., `Tile.tscn` used by `Rack`). When editing UI, prefer modifying the scene resource and keep script API stable (`set_tile_data`, selection signals).
+
+Important extension points for AI changes
+- To add scoring features, register a new rule via `Scoring._register_rule(FuncRef)`; follow `_calculate_basic_word_score` shape.
+- To modify word validation, update `scripts/core/word_checker.gd` or change `dictionary_loader.gd` (keep `DICTIONARY_PATH` constant).
+- To add tile behaviors or special tiles, extend `TileModel` (it uses `class_name TileModel`) and update `BoardModel.place_tile()` checks.
+
+Developer workflows & debugging tips
+- Run and debug in Godot editor (Godot 4). There are no automated tests in the repo — run scenes to reproduce behavior.
+- Quick checks when changing logic:
+  - Verify EventBus signal names (see `autoload/event_bus.gd`) and update any connect calls.
+  - If you change resource paths, use the Godot editor's FileSystem to ensure files are imported correctly.
+
+Files to inspect for context (examples)
+- `autoload/event_bus.gd` — central signals.
+- `autoload/game_manager.gd`, `scenes/main/Main.tscn` — top-level orchestration.
+- `scripts/core/board_model.gd`, `scripts/core/tile_model.gd` — canonical data structures.
+- `scripts/logic/scoring.gd`, `scripts/logic/word_finder.gd` — scoring and word discovery patterns.
+- `scripts/util/dictionary_loader.gd`, `data/english_words.txt` — dictionary and word validation.
+
+Agent rules & expectations (concise)
+- Preserve EventBus names and preloads; changing them requires repo-wide updates.
+- Keep changes small and testable: modify one system at a time (e.g., update scoring rules but keep `evaluate_board()` contract the same).
+- When adding public functions to core models, maintain backward-compatible signatures (BoardModel methods are used by multiple scripts).
+
+What I couldn't infer (ask the user)
+- Which scene is configured as the project root in Godot (I assume `scenes/main/Main.tscn`).
+- Any CI or platform-specific run commands (none found in repo). If you have a preferred Godot CLI or CI config, tell me and I'll include it.
+
+If this looks correct I will add or merge this file into `.github/copilot-instructions.md`. Ask for clarifications or point me at any extra project docs you want merged.

--- a/.github/session_progress.md
+++ b/.github/session_progress.md
@@ -1,0 +1,82 @@
+Session progress snapshot
+========================
+```markdown
+Session progress snapshot
+========================
+
+Date: 2025-11-27
+
+Work completed in this session (safe, minimal changes):
+- Added a non-destructive debug prototype: `scenes/debug/Debug.tscn` and `scripts/debug/word_test.gd` exposing console helpers `validate_word`, `place_tile_for_test`, and `print_board`.
+- Created a small runtime debug UI (CanvasLayer -> Panel -> VBox -> Buttons) so the helpers can be invoked by clicking when the Editor Evaluator is unavailable.
+- Fixed several Godot 4 API mismatches that caused runtime/parser errors:
+  - Replaced `String.empty()` with `String.is_empty()` in `scripts/debug/word_test.gd`.
+  - Replaced `Array.empty()` with `Array.is_empty()` in `autoload/tile_bag.gd`.
+  - Updated Control property usage for Godot 4 (`rect_position`/`rect_size` -> `position`/`size`) used in the runtime UI.
+- Made small, defensive scoring/FuncRef changes to avoid engine-specific `funcref()` typing issues (see `scripts/logic/scoring.gd`).
+- Created/maintained safe backups when the `project.godot` file was edited during import troubleshooting.
+
+What works now (how to reproduce quickly):
+1. Open the project in Godot 4 and run `scenes/debug/Debug.tscn`.
+2. Use the on-screen debug panel (top-left) to validate words, place a tile at (7,7), and print the board.
+3. Debug prints appear in the Output/Debugger console (example: `[word_test] Ready. Dictionary size: 5`).
+
+Remaining warnings & recommended cleanup (options for next session):
+1. Repository hygiene (low-risk): replace any remaining `.empty()` usages with `.is_empty()` and normalize `.gd` indentation to 4 spaces; add an `.editorconfig`.
+2. Iterative repair (medium effort): address remaining warnings (unused parameters/variables, shadowed names like `owner`, duplicate local names like `TileModel`) — either rename or prefix unused ones with `_`.
+3. Make the debug UI persistent in `scenes/debug/Debug.tscn` (so it can be styled and edited in the Editor), or add input fields so you can type arbitrary words/coords from the running UI.
+4. (Optional) Create a small branch/PR with all low-risk fixes so they can be reviewed before merging into the main team repo.
+
+Notes about saving context between sessions:
+- This repository is the single-source of truth for resuming work: commit the changes (or create a branch) before switching machines or sharing with the team.
+- The chat history is ephemeral; storing the progress inside this file and the repo (commits/branches) is the robust way to preserve session context.
+
+If you want me to apply any of the recommended next steps now (add editable inputs, repo-wide `.empty()` -> `.is_empty()` replacements, or create a branch with fixes), tell me which one and I'll implement it.
+
+```
+
+---
+
+Scoring with tiles — proposed implementation plan
+-----------------------------------------------
+Goal: Treat tiles as first-class objects with scoring modifiers and implement a turn-aware scoring flow that mirrors Scrabble rules (cell multipliers consumed when first used, words scored when they include at least one tile placed this turn).
+
+Key decisions
+- Tile lifecycle: three states — NOT_PLACED, PLACED (this turn), VALIDATED (scored). Track `placement_turn` and `validated_turn` so tiles can be revalidated later if needed.
+- Cell multipliers (letter/word) live in BoardModel cell metadata; they are consumed the first time they are applied (classic Scrabble behavior).
+- Scoring evaluates all words that include at least one tile placed this turn. Existing tiles contribute face values but do not re-trigger consumed cell multipliers.
+
+Implementation steps (small, reviewable commits)
+1) TileModel: extend `scripts/core/tile_model.gd`
+  - Add fields: `letter`, `value`, `letter_multiplier`, `word_multiplier`, `temporary_modifiers`, `state`, `placement_turn`, `validated_turn`.
+  - Methods: `mark_placed(turn_id)`, `mark_validated(turn_id)`, `reset_validation()`.
+
+2) BoardModel: add `cell_metadata` and helpers
+  - `cell_metadata[y][x]` -> {letter_multiplier:1, word_multiplier:1, consumed: false}
+  - Helpers: `get_cell_meta(pos)`, `consume_cell_multiplier(pos)`, and keep existing `place_tile(tile, pos, turn_id)` semantics.
+
+3) Scoring: make evaluate_board turn-aware (`placed_positions`, `turn_id`)
+  - Use `WordFinder` to find words, then filter to words including at least one newly-placed tile.
+  - For each tile in a word compute: effective_letter = tile.value * tile.letter_multiplier * (cell_meta.letter_multiplier if tile.placement_turn == turn_id and not cell_meta.consumed)
+  - Accumulate base_sum, aggregate word multipliers (tile.word_multiplier and cell.word_multiplier when applied), multiply at end.
+  - After scoring a word, call `consume_cell_multiplier` on cells that contributed so multipliers are single-use.
+
+4) GameManager integration
+  - Track `_tiles_placed_positions` (or tile refs) for the current turn.
+  - At turn end, call `Scoring.evaluate_board(board.get_grid_state(), _tiles_placed_positions, current_turn)` and then mark `tile.mark_validated(current_turn)` for placed tiles.
+
+5) Tests & debug harness
+  - Add `scripts/debug/score_test.gd` that constructs TileModel instances with canonical Scrabble values, sets cell multipliers, places tiles, calls scoring, and prints expected vs actual.
+  - Extend the runtime debug UI or the `Debug.tscn` scene to run simple scoring scenarios interactively.
+
+Edge cases & notes
+- Blank/wild tiles (value 0) should be supported.
+- Moving tiles before validation should reset `placement_turn` appropriately.
+- Multi-word plays: sum scores for all words formed that include at least one new tile.
+- Provide a non-destructive re-validation mode if you need to preview scoring without consuming multipliers.
+
+Example (Scrabble-like)
+- Word: APPLE with base tile values A=1, P=3, P=3, L=1, E=1
+- If a double-letter exists under the first P (making that P = 6) and a double-word exists under A (applies to whole word because A was placed this turn), compute per above.
+
+If you'd like, I can implement steps 1–4 now (TileModel, BoardModel cell metadata, scoring update, and a debug test) as a set of small commits. Confirm and I'll start applying patches.

--- a/autoload/event_bus.gd
+++ b/autoload/event_bus.gd
@@ -1,0 +1,9 @@
+extends Node
+
+# EventBus: A central hub for signals to decouple game components.
+
+signal tile_placed(tile_data, grid_position)
+signal turn_started(turn_number)
+signal turn_ended(turn_number)
+signal game_over(final_score)
+signal score_updated(new_score)

--- a/autoload/event_bus.gd.uid
+++ b/autoload/event_bus.gd.uid
@@ -1,0 +1,1 @@
+uid://dis0k6umuqfgx

--- a/autoload/game_manager.gd
+++ b/autoload/game_manager.gd
@@ -1,0 +1,85 @@
+extends Node
+
+# GameManager: Controls the main game loop and state.
+
+var _turn_manager = preload("res://scripts/logic/turn_manager.gd").new()
+var _board_model = preload("res://scripts/core/board_model.gd").new()
+var _scoring = preload("res://scripts/logic/scoring.gd").new()
+
+var _current_score = 0
+var _target_score = 100 # Example target score
+const MAX_TURNS = 10 # Example turn limit
+const TILES_PER_TURN = 7
+
+var _tiles_placed_this_turn: int = 0
+
+func _ready():
+	# Connect to signals from the EventBus
+	EventBus.connect("tile_placed", Callable(self, "_on_tile_placed"))
+	EventBus.connect("turn_ended", Callable(self, "_on_turn_ended"))
+
+	# Ensure TileBag is available and expose remaining tiles if needed
+	if TileBag:
+		# TileBag is an autoload; nothing to do here but keep reference
+		pass
+
+	start_new_game()
+
+func start_new_game():
+	_current_score = 0
+	_turn_manager.reset()
+	_board_model._initialize_grid() # Reset the board model
+
+	# Add child nodes for script instances to process
+	add_child(_turn_manager)
+	add_child(_board_model)
+	add_child(_scoring)
+
+	start_next_turn()
+
+func start_next_turn():
+	if _turn_manager.get_current_turn() > MAX_TURNS:
+		end_game()
+		return
+
+	_tiles_placed_this_turn = 0
+	_turn_manager.next_turn()
+	# Emit the turn_started signal; UI and Rack should react to draw tiles.
+	EventBus.emit_signal("turn_started", _turn_manager.get_current_turn())
+	# Optionally pre-fetch tiles from the TileBag (Rack also requests tiles when it hears turn_started)
+	if TileBag:
+		TileBag.draw_tiles(TILES_PER_TURN)
+
+func _on_tile_placed(tile_data, grid_position):
+	# Provisional scoring for placing a tile
+	_current_score += tile_data.value
+	EventBus.emit_signal("score_updated", _current_score)
+
+	# Place the tile in the board model
+	_board_model.place_tile(tile_data, grid_position)
+
+	_tiles_placed_this_turn += 1
+	# If the player placed all tiles for this turn, end the turn
+	if _tiles_placed_this_turn >= TILES_PER_TURN:
+		# Emit turn_ended to trigger scoring and next turn
+		EventBus.emit_signal("turn_ended", _turn_manager.get_current_turn())
+
+func _on_turn_ended(turn_number):
+	# Evaluate the entire board for words and score them
+	var board_state = _board_model.get_grid_state()
+	var turn_score = _scoring.evaluate_board(board_state)
+	_current_score += turn_score
+	EventBus.emit_signal("score_updated", _current_score)
+
+	# Start the next turn
+	start_next_turn()
+
+func end_game():
+	if _current_score >= _target_score:
+		# Player wins
+		EventBus.emit_signal("game_over", _current_score, true)
+	else:
+		# Player loses
+		EventBus.emit_signal("game_over", _current_score, false)
+
+# TODO: Add logic for level progression and increasing target scores.

--- a/autoload/game_manager.gd.uid
+++ b/autoload/game_manager.gd.uid
@@ -1,0 +1,1 @@
+uid://c4cjb6jwmdmpq

--- a/autoload/tile_bag.gd
+++ b/autoload/tile_bag.gd
@@ -1,0 +1,53 @@
+extends Node
+
+# TileBag: Generates and provides letter tiles.
+
+signal tiles_drawn(new_tiles)
+
+# Based on Scrabble letter distribution and values.
+const LETTER_DISTRIBUTION = {
+	"A": {"count": 9, "value": 1}, "B": {"count": 2, "value": 3},
+	"C": {"count": 2, "value": 3}, "D": {"count": 4, "value": 2},
+	"E": {"count": 12, "value": 1}, "F": {"count": 2, "value": 4},
+	"G": {"count": 3, "value": 2}, "H": {"count": 2, "value": 4},
+	"I": {"count": 9, "value": 1}, "J": {"count": 1, "value": 8},
+	"K": {"count": 1, "value": 5}, "L": {"count": 4, "value": 1},
+	"M": {"count": 2, "value": 3}, "N": {"count": 6, "value": 1},
+	"O": {"count": 8, "value": 1}, "P": {"count": 2, "value": 3},
+	"Q": {"count": 1, "value": 10}, "R": {"count": 6, "value": 1},
+	"S": {"count": 4, "value": 1}, "T": {"count": 6, "value": 1},
+	"U": {"count": 4, "value": 1}, "V": {"count": 2, "value": 4},
+	"W": {"count": 2, "value": 4}, "X": {"count": 1, "value": 8},
+	"Y": {"count": 2, "value": 4}, "Z": {"count": 1, "value": 10}
+}
+
+var _tile_pool = []
+
+func _ready():
+	_initialize_tile_pool()
+
+func _initialize_tile_pool():
+	_tile_pool.clear()
+	for letter in LETTER_DISTRIBUTION:
+		var data = LETTER_DISTRIBUTION[letter]
+		for i in range(data["count"]):
+			_tile_pool.append(TileModel.new(letter, data["value"]))
+	
+	_tile_pool.shuffle()
+
+func draw_tiles(count: int):
+	var drawn_tiles = []
+	for i in range(count):
+		# Use Array.is_empty() in Godot 4; `empty()` is not a method on Array
+		if _tile_pool.is_empty():
+			# TODO: Handle empty tile bag scenario (e.g., end game)
+			break
+		drawn_tiles.append(_tile_pool.pop_front())
+	
+	emit_signal("tiles_drawn", drawn_tiles)
+	return drawn_tiles
+
+func get_remaining_tile_count() -> int:
+	return _tile_pool.size()
+
+# TODO: Add functionality to return tiles to the bag if needed.

--- a/autoload/tile_bag.gd.uid
+++ b/autoload/tile_bag.gd.uid
@@ -1,0 +1,1 @@
+uid://cuxghahd77g2k

--- a/data/english_words.txt
+++ b/data/english_words.txt
@@ -1,0 +1,5 @@
+apple
+banana
+cat
+dog
+elephant

--- a/project.godot
+++ b/project.godot
@@ -10,10 +10,21 @@ config_version=5
 
 [application]
 
-config/name="scrabblerabble"
-config/features=PackedStringArray("4.5", "Forward Plus")
-config/icon="res://icon.svg"
+config/name="Wordatro"
+config/version="0.1"
+run/main_scene="res://scenes/debug/Debug.tscn"
+config/features=PackedStringArray("4.5")
 
-[dotnet]
+[autoload]
 
-project/assembly_name="scrabblerabble"
+EventBus="*res://autoload/event_bus.gd"
+GameManager="*res://autoload/game_manager.gd"
+TileBag="*res://autoload/tile_bag.gd"
+
+[display]
+
+window/size/width=1536
+window/size/height=864
+window/test_width=1536
+window/test_height=864
+window/resizable=true

--- a/project.godot.bak
+++ b/project.godot.bak
@@ -1,0 +1,44 @@
+
+; Backup of previous project.godot
+; This was captured before attempting to rewrite autoload entries.
+; Use this file to restore the previous state if necessary.
+
+config_version=5
+
+[application]
+
+config/name="Wordatro"
+config/version="0.1"
+run/main_scene="res://scenes/main/Main.tscn"
+config/features=PackedStringArray("4.5")
+
+[autoload]
+
+EventBus="*res://autoload/event_bus.gd"
+EventBus/Enabled=true
+EventBus/NodeName="EventBus"
+GameManager="*res://autoload/game_manager.gd"
+GameManager/Enabled=true
+GameManager/NodeName="GameManager"
+TileBag="*res://autoload/tile_bag.gd"
+TileBag/Enabled=true
+TileBag/NodeName="TileBag"
+"#NOTE:SomeGodoteditorsexpectautoloadentriesinaspecificformat.#Ifyouseeerrorsaboutfailingtoinstantiateautoloads,register#thefollowingsingletonsfromtheGodoteditorProject>ProjectSettings>Autoload#withthesepaths:#-EventBus->res://autoload/event_bus.gd#-GameManager->res://autoload/game_manager.gd#-TileBag->res://autoload/tile_bag.gd#TheeditorwillwritethecorrectformatforyourversionofGodot.[description]name"="Wordatro - Scrabble-like MVP"
+author=""
+version="0.1"
+license=""
+
+[description]
+
+name="Wordatro - Scrabble-like MVP"
+author=""
+version="0.1"
+license=""
+
+[display]
+
+window/size/width=1280
+window/size/height=720
+window/test_width=1280
+window/test_height=720
+window/resizable=true

--- a/project.godot.pre_import.bak
+++ b/project.godot.pre_import.bak
@@ -1,0 +1,37 @@
+; Backup of project.godot before minimal rewrite
+; Saved on rewrite attempt so the previous full file can be restored if needed.
+
+; Original project.godot contents copied below for recovery:
+
+; --- begin original ---
+; config_version=5
+
+[application]
+
+config/name="Wordatro"
+config/version="0.1"
+run/main_scene="res://scenes/main/Main.tscn"
+config/features=PackedStringArray("4.5")
+
+[autoload]
+paths=PackedStringArray("res://autoload/event_bus.gd","res://autoload/game_manager.gd","res://autoload/tile_bag.gd")
+names=PackedStringArray("EventBus","GameManager","TileBag")
+enabled=PackedBoolArray(true,true,true)
+nodes=PackedStringArray("EventBus","GameManager","TileBag")
+
+[description]
+
+name="Wordatro - Scrabble-like MVP"
+author=""
+version="0.1"
+license=""
+
+[display]
+
+window/size/width=1280
+window/size/height=720
+window/test_width=1280
+window/test_height=720
+window/resizable=true
+
+; --- end original ---

--- a/scenes/board/Board.tscn
+++ b/scenes/board/Board.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3 uid="uid://b1y2x3k4l5m6n"]
+
+[ext_resource type="Script" path="res://scenes/board/board.gd" id="1_abcde"]
+
+[node name="Board" type="Node2D"]
+script = ExtResource("1_abcde")

--- a/scenes/board/board.gd
+++ b/scenes/board/board.gd
@@ -1,0 +1,37 @@
+extends Node2D
+
+# Board: Visual/scene wrapper for the logical BoardModel.
+# Responsibilities:
+# - Convert world/global positions to grid coordinates
+# - Optionally snap tile visuals to cell centers
+# - Provide a small API used by Tile nodes and other UI code
+
+const BOARD_WIDTH := 15
+const BOARD_HEIGHT := 15
+@export var cell_size: int = 60 # pixels per cell; keep consistent with Rack TILE_SPACING
+
+func _ready():
+	# No heavy logic here; BoardModel (data) is handled by GameManager/BoardModel
+	pass
+
+func world_to_grid(global_pos: Vector2) -> Vector2i:
+	# Convert a global position (tile.global_position) into a Vector2i grid coordinate
+	var local = to_local(global_pos)
+	var gx = int(floor(local.x / cell_size))
+	var gy = int(floor(local.y / cell_size))
+	return Vector2i(gx, gy)
+
+func grid_to_world(grid_pos: Vector2i) -> Vector2:
+	# Return the world position for the center of a cell
+	var local_x = grid_pos.x * cell_size + cell_size * 0.5
+	var local_y = grid_pos.y * cell_size + cell_size * 0.5
+	return to_global(Vector2(local_x, local_y))
+
+func is_valid_grid_pos(grid_pos: Vector2i) -> bool:
+	return grid_pos.x >= 0 and grid_pos.x < BOARD_WIDTH and grid_pos.y >= 0 and grid_pos.y < BOARD_HEIGHT
+
+func snap_tile_to_grid(tile_node: Node2D, grid_pos: Vector2i) -> void:
+	# Move the tile node to the center of the given grid cell
+	var world = grid_to_world(grid_pos)
+	tile_node.global_position = world
+

--- a/scenes/board/board.gd.uid
+++ b/scenes/board/board.gd.uid
@@ -1,0 +1,1 @@
+uid://c2fuhtruwoq5d

--- a/scenes/debug/Debug.tscn
+++ b/scenes/debug/Debug.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3 uid="uid://36g2gf7ulme7"]
+
+[ext_resource type="Script" uid="uid://byyivub0ihq06" path="res://scripts/debug/word_test.gd" id="1"]
+
+[node name="WordTest" type="Node"]
+script = ExtResource("1")

--- a/scenes/debug/DebugUI.tscn
+++ b/scenes/debug/DebugUI.tscn
@@ -1,0 +1,42 @@
+[gd_scene load_steps=4 format=3 uid="uid://bcfoi8jyyux4l"]
+
+[ext_resource type="PackedScene" uid="uid://ru328m1mgpqe" path="res://scenes/debug/LeftActionPanel.tscn" id="1"]
+[ext_resource type="PackedScene" uid="uid://de0upbdw3f8nd" path="res://scenes/debug/PlacementPanel.tscn" id="2"]
+[ext_resource type="PackedScene" path="res://scenes/ui/BoardView.tscn" id="3"]
+
+[node name="DebugUI" type="CanvasLayer"]
+
+[node name="DebugUI#DebugPanel" type="Panel" parent="."]
+offset_left = 10.0
+offset_top = 10.0
+offset_right = 10.0
+offset_bottom = 10.0
+
+[node name="DebugUI#LeftActionPanel" parent="." instance=ExtResource("1")]
+offset_left = 20.0
+offset_top = 40.0
+offset_right = 20.0
+offset_bottom = 40.0
+
+[node name="DebugUI#BoardView" parent="." instance=ExtResource("3")]
+layout_mode = 3
+anchors_preset = 0
+offset_left = 240.0
+offset_top = 10.0
+offset_right = 240.0
+offset_bottom = 10.0
+
+[node name="DebugUI#PlacementPanel" parent="." instance=ExtResource("2")]
+offset_left = -2.0963135
+offset_top = -74.1817
+offset_right = -2.0963135
+offset_bottom = -74.1817
+
+[node name="BottomHelp" type="Label" parent="."]
+offset_left = 349.0
+offset_top = 621.0
+offset_right = 674.0
+offset_bottom = 645.0
+text = "Click board to place; right‑click to remove."
+horizontal_alignment = 1
+vertical_alignment = 2

--- a/scenes/debug/LeftActionPanel.tscn
+++ b/scenes/debug/LeftActionPanel.tscn
@@ -1,0 +1,86 @@
+[gd_scene format=3 uid="uid://ru328m1mgpqe"]
+
+[node name="LeftActionPanel" type="Panel"]
+
+[node name="LeftActionPanel#LeftActions" type="VBoxContainer" parent="."]
+custom_minimum_size = Vector2(140, 0)
+layout_mode = 0
+offset_top = 183.0
+offset_right = 180.0
+offset_bottom = 390.0
+
+[node name="LeftActions#WordRow" type="HBoxContainer" parent="."]
+layout_mode = 0
+offset_left = 87.0
+offset_top = 209.0
+offset_right = 87.0
+offset_bottom = 209.0
+
+[node name="WordRow#Label" type="Label" parent="."]
+layout_mode = 0
+offset_left = 82.0
+offset_top = 196.0
+offset_right = 129.0
+offset_bottom = 219.0
+text = "Word:"
+
+[node name="WordRow#WordInput" type="LineEdit" parent="."]
+custom_minimum_size = Vector2(80, 0)
+layout_mode = 0
+offset_top = 191.0
+offset_right = 80.0
+offset_bottom = 222.0
+placeholder_text = "type a word"
+
+[node name="WordRow#Check" type="Button" parent="."]
+custom_minimum_size = Vector2(46, 22)
+layout_mode = 0
+offset_left = 123.0
+offset_top = 358.0
+offset_right = 178.0
+offset_bottom = 389.0
+text = "Check"
+
+[node name="LeftActions#Validate" type="Button" parent="."]
+custom_minimum_size = Vector2(120, 20)
+layout_mode = 0
+offset_left = 2.0
+offset_top = 325.0
+offset_right = 122.0
+offset_bottom = 356.0
+text = "Validate"
+
+[node name="LeftActions#PlaceA" type="Button" parent="."]
+custom_minimum_size = Vector2(120, 20)
+layout_mode = 0
+offset_top = 223.0
+offset_right = 120.0
+offset_bottom = 254.0
+text = "Place A"
+
+[node name="LeftActions#Print" type="Button" parent="."]
+custom_minimum_size = Vector2(120, 20)
+layout_mode = 0
+offset_left = 1.0
+offset_top = 258.0
+offset_right = 121.0
+offset_bottom = 289.0
+text = "Print"
+
+[node name="LeftActions#RemoveAll" type="Button" parent="."]
+custom_minimum_size = Vector2(120, 20)
+layout_mode = 0
+offset_top = 293.0
+offset_right = 120.0
+offset_bottom = 324.0
+text = "Remove All"
+
+[node name="LeftActions#EvaluateBtn" type="Button" parent="."]
+custom_minimum_size = Vector2(120, 20)
+layout_mode = 0
+offset_left = 2.0
+offset_top = 357.0
+offset_right = 122.0
+offset_bottom = 388.0
+disabled = true
+text = "Evaluate"

--- a/scenes/debug/PlacementPanel.tscn
+++ b/scenes/debug/PlacementPanel.tscn
@@ -1,0 +1,73 @@
+[gd_scene format=3 uid="uid://de0upbdw3f8nd"]
+
+[node name="PlacementPanel" type="Panel"]
+anchors_preset = 6
+anchor_left = 1.0
+anchor_top = 0.5
+anchor_right = 1.0
+anchor_bottom = 0.5
+grow_horizontal = 0
+grow_vertical = 2
+
+[node name="PlacementPanel#PlaceRow" type="VBoxContainer" parent="."]
+custom_minimum_size = Vector2(96, 0)
+layout_mode = 0
+offset_left = -172.0
+offset_top = -24.0
+offset_right = -4.0
+offset_bottom = 73.0
+alignment = 1
+
+[node name="PlaceRow#LetterInput" type="LineEdit" parent="."]
+custom_minimum_size = Vector2(64, 0)
+layout_mode = 0
+offset_left = -87.0
+offset_top = -20.0
+offset_right = -18.4375
+offset_bottom = 11.0
+placeholder_text = "A"
+
+[node name="PlaceRow#SelectedLetterLabel" type="Label" parent="."]
+custom_minimum_size = Vector2(80, 0)
+layout_mode = 0
+offset_left = -168.0
+offset_top = -15.0
+offset_right = -83.0
+offset_bottom = 8.0
+text = "Selected:"
+
+[node name="PlaceRow#XInput" type="LineEdit" parent="."]
+custom_minimum_size = Vector2(64, 0)
+layout_mode = 0
+offset_left = -169.0
+offset_top = 10.0
+offset_right = -100.4375
+offset_bottom = 41.0
+placeholder_text = "x"
+
+[node name="PlaceRow#YInput" type="LineEdit" parent="."]
+custom_minimum_size = Vector2(64, 0)
+layout_mode = 0
+offset_left = -169.0
+offset_top = 41.0
+offset_right = -100.4375
+offset_bottom = 72.0
+placeholder_text = "y"
+
+[node name="PlaceRow#Place" type="Button" parent="."]
+custom_minimum_size = Vector2(80, 20)
+layout_mode = 0
+offset_left = -89.0
+offset_top = 11.0
+offset_right = -9.0
+offset_bottom = 42.0
+text = "Place"
+
+[node name="PlaceRow#Remove" type="Button" parent="."]
+custom_minimum_size = Vector2(80, 20)
+layout_mode = 0
+offset_left = -90.0
+offset_top = 42.0
+offset_right = -10.0
+offset_bottom = 73.0
+text = "Remove"

--- a/scenes/main/Main.tscn
+++ b/scenes/main/Main.tscn
@@ -1,0 +1,17 @@
+[gd_scene load_steps=5 format=3 uid="uid://c6g8f7j1v2w3x"]
+
+[ext_resource type="PackedScene" uid="uid://b1y2x3k4l5m6n" path="res://scenes/board/Board.tscn" id="1_abcde"]
+[ext_resource type="PackedScene" uid="uid://bd1cu4kvxwocs" path="res://scenes/rack/Rack.tscn" id="2_fghij"]
+[ext_resource type="PackedScene" uid="uid://blbk1u34ldh5s" path="res://scenes/ui/HUD.tscn" id="3_klmno"]
+[ext_resource type="Script" uid="uid://dgufq34t86vo3" path="res://scenes/main/main.gd" id="4_pqrst"]
+
+[node name="Main" type="Node2D"]
+script = ExtResource("4_pqrst")
+
+[node name="Board" parent="." instance=ExtResource("1_abcde")]
+position = Vector2(100, 100)
+
+[node name="Rack" parent="." instance=ExtResource("2_fghij")]
+position = Vector2(100, 700)
+
+[node name="HUD" parent="." instance=ExtResource("3_klmno")]

--- a/scenes/main/main.gd
+++ b/scenes/main/main.gd
@@ -1,0 +1,16 @@
+extends Node2D
+
+# Main: Initializes the game and connects the primary scenes.
+
+@onready var board = $Board
+@onready var rack = $Rack
+@onready var hud = $HUD
+
+func _ready():
+	# The GameManager will start the first turn automatically.
+	# The Rack listens for the 'turn_started' signal to draw tiles.
+	pass
+
+# TODO: Implement input handling for tile movement and placement,
+# possibly by connecting signals from the Board and Rack to a central
+# input handler in this script or in the GameManager.

--- a/scenes/main/main.gd.uid
+++ b/scenes/main/main.gd.uid
@@ -1,0 +1,1 @@
+uid://dgufq34t86vo3

--- a/scenes/rack/Rack.tscn
+++ b/scenes/rack/Rack.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3 uid="uid://e8f7g6h5i4j3k"]
+
+[ext_resource type="Script" path="res://scenes/rack/rack.gd" id="1_lmnop"]
+
+[node name="Rack" type="Node2D"]
+script = ExtResource("1_lmnop")

--- a/scenes/rack/rack.gd
+++ b/scenes/rack/rack.gd
@@ -1,0 +1,70 @@
+extends Node2D
+
+# Rack: Holds and manages the player's tiles for the current turn.
+
+const RACK_SIZE = 7
+const TILE_SPACING = 60 # Pixels between tiles
+
+var _tiles = []
+var _selected_tile = null
+
+var TileScene = preload("res://scenes/tile/Tile.tscn")
+
+func _ready():
+	# Connect to the TileBag to receive new tiles
+	# This assumes TileBag has a signal `tiles_drawn(new_tiles)`
+	if TileBag:
+		TileBag.connect("tiles_drawn", Callable(self, "_on_TileBag_tiles_drawn"))
+
+	# Listen for turn_started so the rack can request a fresh hand
+	EventBus.connect("turn_started", Callable(self, "_on_turn_started"))
+
+func draw_new_hand():
+	# Clear existing tiles
+	for tile in _tiles:
+		tile.queue_free()
+	_tiles.clear()
+
+	# Request new tiles from the TileBag
+	if TileBag:
+		TileBag.draw_tiles(RACK_SIZE)
+
+func _on_TileBag_tiles_drawn(new_tile_data_array):
+	for i in range(new_tile_data_array.size()):
+		var tile_data = new_tile_data_array[i]
+		var new_tile = TileScene.instance()
+		new_tile.set_tile_data(tile_data)
+		new_tile.position = Vector2(i * TILE_SPACING, 0)
+
+		# Connect to the tile's selected signal
+		new_tile.connect("tile_selected", Callable(self, "_on_tile_selected"))
+		# Remove tile from rack when it's placed on board
+		new_tile.connect("tile_placed", Callable(self, "_on_tile_placed"))
+
+		add_child(new_tile)
+		_tiles.append(new_tile)
+
+func _on_tile_selected(selected_tile):
+	if _selected_tile and _selected_tile != selected_tile:
+		_selected_tile.deselect()
+
+	_selected_tile = selected_tile
+	# The tile itself handles the visual selection feedback.
+	# The rack just needs to know which one is active.
+
+func _on_tile_placed(placed_tile, grid_pos):
+	# Remove the visual tile from the rack list if it exists there
+	if placed_tile in _tiles:
+		_tiles.erase(placed_tile)
+	# Optionally free the tile node if the tile isn't already parented elsewhere
+	if is_instance_valid(placed_tile):
+		# keep the node in the scene for visual placement (Board.snap_tile_to_grid moved it)
+		# If you want to remove the node after placement, uncomment the next line:
+		# placed_tile.queue_free()
+		pass
+
+func _on_turn_started(turn_number):
+	# Draw a new hand when a new turn starts
+	draw_new_hand()
+
+# TODO: Implement logic to remove a tile from the rack when it's placed on the board.

--- a/scenes/rack/rack.gd.uid
+++ b/scenes/rack/rack.gd.uid
@@ -1,0 +1,1 @@
+uid://bbwl1244tfy1c

--- a/scenes/tile/Tile.tscn
+++ b/scenes/tile/Tile.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3 uid="uid://d2o3p4q5r6s7t"]
+
+[ext_resource type="Script" path="res://scenes/tile/tile.gd" id="1_vwxyz"]
+
+[node name="Tile" type="Node2D"]
+script = ExtResource("1_vwxyz")

--- a/scenes/tile/tile.gd
+++ b/scenes/tile/tile.gd
@@ -1,0 +1,98 @@
+extends Node2D
+
+# Tile: Represents a single letter tile with its value.
+# Handles user interaction like selection and placement.
+
+signal tile_selected(tile)
+signal tile_placed(tile, board_pos)
+
+var tile_data: TileModel
+var is_selected: bool = false
+
+var _dragging: bool = false
+var _drag_offset: Vector2 = Vector2.ZERO
+
+# Placeholder visual elements (may be replaced by scene visuals)
+@onready var _sprite: Sprite2D = $Sprite2D if has_node("Sprite2D") else null
+@onready var _label: Label = $Label if has_node("Label") else null
+
+func _ready():
+	# If the scene did not include a label/sprite, create a simple label for debugging
+	if not _label:
+		_label = Label.new()
+		add_child(_label)
+
+	if tile_data and _label:
+		_label.text = tile_data.letter
+
+func set_tile_data(p_tile_data: TileModel):
+	tile_data = p_tile_data
+	if _label:
+		_label.text = tile_data.letter
+
+func select():
+	is_selected = true
+	modulate = Color(0.9, 0.9, 1.1)
+	emit_signal("tile_selected", self)
+
+func deselect():
+	is_selected = false
+	modulate = Color(1, 1, 1)
+
+func _unhandled_input(event):
+	# Mouse/drag handling
+	if event is InputEventMouseButton:
+		if event.button_index == MOUSE_BUTTON_LEFT:
+			if event.pressed:
+				# start dragging only if the mouse is over this tile
+				var local_mouse = to_local(get_global_mouse_position())
+				# simple bounds check based on cell size if available
+				_drag_offset = position - local_mouse
+				if is_selected:
+					_dragging = true
+			else:
+				if _dragging:
+					_dragging = false
+					# On release, find the board and emit tile_placed with grid pos
+					var board = get_tree().get_root().find_node("Board", true, false)
+					if board:
+						var grid_pos = board.world_to_grid(global_position)
+						if board.is_valid_grid_pos(grid_pos):
+							# Notify via EventBus so GameManager and other systems react
+							EventBus.emit_signal("tile_placed", tile_data, grid_pos)
+							emit_signal("tile_placed", self, grid_pos)
+							# Snap visually to the grid
+							board.snap_tile_to_grid(self, grid_pos)
+							return
+					# If we reach here, placement failed; return to origin or leave where released
+					pass
+
+	# Drag motion
+	if event is InputEventMouseMotion and _dragging:
+		global_position = get_global_mouse_position() + _drag_offset
+
+	# Keyboard movement when selected
+	if event is InputEventKey and event.pressed and is_selected:
+		var board = get_tree().get_root().find_node("Board", true, false)
+		var step = 60
+		if board and board.has_method("cell_size") == false:
+			# if board provides cell_size as export var
+			step = board.cell_size if board.has_method("cell_size") == false else step
+
+		match event.scancode:
+			KEY_W, KEY_UP:
+				global_position.y -= board.cell_size if board else step
+			KEY_S, KEY_DOWN:
+				global_position.y += board.cell_size if board else step
+			KEY_A, KEY_LEFT:
+				global_position.x -= board.cell_size if board else step
+			KEY_D, KEY_RIGHT:
+				global_position.x += board.cell_size if board else step
+			KEY_SPACE:
+				# Place at current position
+				if board:
+					var grid_pos = board.world_to_grid(global_position)
+					if board.is_valid_grid_pos(grid_pos):
+						EventBus.emit_signal("tile_placed", tile_data, grid_pos)
+						emit_signal("tile_placed", self, grid_pos)
+						board.snap_tile_to_grid(self, grid_pos)

--- a/scenes/tile/tile.gd.uid
+++ b/scenes/tile/tile.gd.uid
@@ -1,0 +1,1 @@
+uid://3swipn10arpc

--- a/scenes/ui/BoardView.tscn
+++ b/scenes/ui/BoardView.tscn
@@ -1,0 +1,9 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource path="res://scripts/ui/board_view.gd" type="Script" id=1]
+
+[node name="BoardView" type="Control"]
+script = ExtResource( 1 )
+rect_min_size = Vector2(528, 528)
+
+# You can edit `cols`, `rows`, and `cell_size` in the Inspector because they're exported in the script.

--- a/scenes/ui/HUD.tscn
+++ b/scenes/ui/HUD.tscn
@@ -1,0 +1,43 @@
+[gd_scene load_steps=2 format=3 uid="uid://q1w2e3r4t5y6u"]
+
+[ext_resource type="Script" path="res://scenes/ui/hud.gd" id="1_ijklm"]
+
+[node name="HUD" type="CanvasLayer"]
+script = ExtResource("1_ijklm")
+
+[node name="TurnLabel" type="Label" parent="."]
+offset_left = 20.0
+offset_top = 20.0
+offset_right = 120.0
+offset_bottom = 43.0
+text = "Turn: 1"
+
+[node name="ScoreLabel" type="Label" parent="."]
+offset_left = 20.0
+offset_top = 50.0
+offset_right = 120.0
+offset_bottom = 73.0
+text = "Score: 0"
+
+[node name="TargetLabel" type="Label" parent="."]
+offset_left = 20.0
+offset_top = 80.0
+offset_right = 120.0
+offset_bottom = 103.0
+text = "Target: 100"
+
+[node name="GameOverLabel" type="Label" parent="."]
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -100.0
+offset_top = -50.0
+offset_right = 100.0
+offset_bottom = 50.0
+grow_horizontal = 2
+grow_vertical = 2
+text = "Game Over"
+horizontal_alignment = 1
+vertical_alignment = 1

--- a/scenes/ui/hud.gd
+++ b/scenes/ui/hud.gd
@@ -1,0 +1,33 @@
+extends CanvasLayer
+
+# HUD: Displays game information like score, turn, etc.
+
+# Node references (to be assigned in the editor)
+@onready var turn_label: Label = $TurnLabel
+@onready var score_label: Label = $ScoreLabel
+@onready var target_label: Label = $TargetLabel
+@onready var game_over_label: Label = $GameOverLabel
+
+func _ready():
+	EventBus.connect("turn_started", Callable(self, "_on_turn_started"))
+	EventBus.connect("score_updated", Callable(self, "_on_score_updated"))
+	EventBus.connect("game_over", Callable(self, "_on_game_over"))
+	
+	game_over_label.hide()
+
+func _on_turn_started(turn_number: int):
+	turn_label.text = "Turn: %d" % turn_number
+	game_over_label.hide()
+
+func _on_score_updated(new_score: int):
+	score_label.text = "Score: %d" % new_score
+
+func _on_game_over(final_score: int, did_win: bool):
+	game_over_label.show()
+	if did_win:
+		game_over_label.text = "You Win!\nFinal Score: %d" % final_score
+	else:
+		game_over_label.text = "Game Over\nFinal Score: %d" % final_score
+
+func set_target_score(target: int):
+	target_label.text = "Target: %d" % target

--- a/scenes/ui/hud.gd.uid
+++ b/scenes/ui/hud.gd.uid
@@ -1,0 +1,1 @@
+uid://cqk3dsqvmm6f7

--- a/scripts/core/board_model.gd
+++ b/scripts/core/board_model.gd
@@ -1,0 +1,149 @@
+extends Node
+
+# BoardModel: Data model for the game board.
+# Stores the state of the 15x15 grid.
+
+const BOARD_WIDTH = 15
+const BOARD_HEIGHT = 15
+
+var _grid = []
+var _temp_placements = {} # key: "x,y" -> TileModel for temporary placements this turn
+var _placed_positions_this_turn = [] # Array of Vector2i
+
+func _ready():
+	_initialize_grid()
+
+func _initialize_grid():
+	_grid.resize(BOARD_HEIGHT)
+	for y in range(BOARD_HEIGHT):
+		_grid[y] = []
+		_grid[y].resize(BOARD_WIDTH)
+		for x in range(BOARD_WIDTH):
+			_grid[y][x] = null
+
+func _pos_key(grid_pos: Vector2i) -> String:
+	return str(grid_pos.x) + "," + str(grid_pos.y)
+
+func _key_to_pos(key: String) -> Vector2i:
+	var parts = key.split(",")
+	return Vector2i(int(parts[0]), int(parts[1]))
+
+func place_tile(tile_data, grid_pos: Vector2i, temporary: bool = false) -> bool:
+	# If temporary, place into _temp_placements for this turn only.
+	if not is_valid_position(grid_pos):
+		return false
+
+	var key = _pos_key(grid_pos)
+	if temporary:
+		# don't allow temp placement on top of a committed tile
+		if _grid[grid_pos.y][grid_pos.x] != null:
+			return false
+		_temp_placements[key] = tile_data
+		# track positions placed this turn
+		if not _placed_positions_this_turn.has(grid_pos):
+			_placed_positions_this_turn.append(grid_pos)
+		return true
+
+	# permanent placement: fail if occupied
+	if _grid[grid_pos.y][grid_pos.x] != null:
+		return false # Position already occupied
+
+	_grid[grid_pos.y][grid_pos.x] = tile_data
+	return true
+
+func get_tile(grid_pos: Vector2i):
+	if not is_valid_position(grid_pos):
+		return null
+	return _grid[grid_pos.y][grid_pos.x]
+
+func get_combined_tile(grid_pos: Vector2i):
+	# Return the tile at pos, considering temporary placements first
+	var key = _pos_key(grid_pos)
+	if _temp_placements.has(key):
+		return _temp_placements[key]
+	return get_tile(grid_pos)
+
+func is_valid_position(grid_pos: Vector2i) -> bool:
+	return (grid_pos.x >= 0 and grid_pos.x < BOARD_WIDTH and 
+			grid_pos.y >= 0 and grid_pos.y < BOARD_HEIGHT)
+
+func get_grid_state() -> Array:
+	return _grid
+
+func get_combined_grid_view() -> Array:
+	# Return a lightweight 2D array of tiles (TileModel or null) merging temp placements over committed grid
+	var view = []
+	view.resize(BOARD_HEIGHT)
+	for y in range(BOARD_HEIGHT):
+		view[y] = []
+		for x in range(BOARD_WIDTH):
+			var pos = Vector2i(x, y)
+			view[y].append(get_combined_tile(pos))
+	return view
+
+func get_temp_positions() -> Array:
+	return _placed_positions_this_turn.duplicate()
+
+func remove_temp_tile(grid_pos: Vector2i) -> void:
+	var key = _pos_key(grid_pos)
+	if _temp_placements.has(key):
+		_temp_placements.erase(key)
+	# remove from placed positions array
+	for i in range(_placed_positions_this_turn.size()-1, -1, -1):
+		if _placed_positions_this_turn[i] == grid_pos:
+			_placed_positions_this_turn.remove_at(i)
+
+func clear_temp_tiles() -> void:
+	_temp_placements.clear()
+	_placed_positions_this_turn.clear()
+
+func commit_temp_tiles(turn_id: int) -> void:
+	# Move temp placements into the committed grid, mark placement turn on TileModel if available
+	for key in _temp_placements.keys():
+		var pos = _key_to_pos(key)
+		var tile = _temp_placements[key]
+		_grid[pos.y][pos.x] = tile
+		if typeof(tile) == TYPE_OBJECT and tile.has_method("mark_placed"):
+			tile.mark_placed(turn_id)
+	clear_temp_tiles()
+
+func get_candidate_ranges_for_positions(positions: Array) -> Array:
+	# For each position, scan horizontally and vertically in the combined view and return unique ranges
+	var combined = get_combined_grid_view()
+	var ranges = []
+	var seen = {}
+
+	for pos in positions:
+		# horizontal
+		var y = pos.y
+		var x = pos.x
+		var sx = x
+		while sx > 0 and combined[y][sx - 1] != null:
+			sx -= 1
+		var ex = x
+		while ex < BOARD_WIDTH - 1 and combined[y][ex + 1] != null:
+			ex += 1
+		if ex - sx + 1 >= 2:
+			var key = str(sx) + ":" + str(y) + "-" + str(ex) + ":" + str(y)
+			if not seen.has(key):
+				seen[key] = true
+				ranges.append({"start": Vector2i(sx, y), "end": Vector2i(ex, y)})
+
+		# vertical
+		var sx2 = x
+		var sy = pos.y
+		var sy_start = sy
+		while sy_start > 0 and combined[sy_start - 1][sx2] != null:
+			sy_start -= 1
+		var sy_end = sy
+		while sy_end < BOARD_HEIGHT - 1 and combined[sy_end + 1][sx2] != null:
+			sy_end += 1
+		if sy_end - sy_start + 1 >= 2:
+			var key2 = str(x) + ":" + str(sy_start) + "-" + str(x) + ":" + str(sy_end)
+			if not seen.has(key2):
+				seen[key2] = true
+				ranges.append({"start": Vector2i(x, sy_start), "end": Vector2i(x, sy_end)})
+
+	return ranges
+
+# TODO: Add methods for handling special tiles or board multipliers.

--- a/scripts/core/board_model.gd.uid
+++ b/scripts/core/board_model.gd.uid
@@ -1,0 +1,1 @@
+uid://d4a08ysajs4w6

--- a/scripts/core/tile_model.gd
+++ b/scripts/core/tile_model.gd
@@ -1,0 +1,60 @@
+extends Node
+
+# TileModel: Data model for a single tile.
+# Stores letter, point value, modifiers and lifecycle state.
+
+class_name TileModel
+
+enum State { NOT_PLACED, PLACED, VALIDATED }
+
+var letter: String = ""
+var value: int = 0
+
+# Per-tile modifiers (defaults)
+var letter_multiplier: int = 1
+var word_multiplier: int = 1
+var temporary_modifiers: Dictionary = {}
+var placement_multiplier: int = 1 # contributes to final score multiplier (default 1)
+
+# Lifecycle
+var state: int = State.NOT_PLACED
+var placement_turn: int = -1
+var validated_turn: int = -1
+
+func _init(p_letter: String = "", p_value: int = 0):
+	letter = p_letter
+	value = p_value
+
+func mark_placed(turn_id: int) -> void:
+	state = State.PLACED
+	placement_turn = turn_id
+	validated_turn = -1
+
+func mark_validated(turn_id: int) -> void:
+	state = State.VALIDATED
+	validated_turn = turn_id
+
+func reset_validation() -> void:
+	validated_turn = -1
+	if placement_turn == -1:
+		state = State.NOT_PLACED
+
+# Helper: effective letter value taking into account letter_multiplier
+func effective_letter_value() -> int:
+	return value * letter_multiplier
+
+func add_modifier(mod_name: String, data = null) -> void:
+	# Example modifier name: "bonus_multiplier_2" -> sets placement_multiplier to 2
+	temporary_modifiers[mod_name] = data
+	if mod_name.begins_with("bonus_multiplier_"):
+		var parts = mod_name.split("_")
+		var v = int(parts[2]) if parts.size() > 2 else 1
+		placement_multiplier = v
+
+func clear_modifier(mod_name: String) -> void:
+	if temporary_modifiers.has(mod_name):
+		temporary_modifiers.erase(mod_name)
+	# Reset placement multiplier if modifier removed and no other modifier sets it
+	# For simplicity, reset to 1 (further logic could recompute from remaining modifiers)
+	placement_multiplier = 1
+

--- a/scripts/core/tile_model.gd.uid
+++ b/scripts/core/tile_model.gd.uid
@@ -1,0 +1,1 @@
+uid://ba5lxiv271q1k

--- a/scripts/core/word_checker.gd
+++ b/scripts/core/word_checker.gd
@@ -1,0 +1,12 @@
+extends Node
+
+# WordChecker: Validates words against the loaded dictionary.
+
+var _dictionary = {}
+var _loader = preload("res://scripts/util/dictionary_loader.gd").new()
+
+func _ready():
+	_dictionary = _loader.load_dictionary()
+
+func is_valid_word(word: String) -> bool:
+	return _dictionary.has(word.to_lower())

--- a/scripts/core/word_checker.gd.uid
+++ b/scripts/core/word_checker.gd.uid
@@ -1,0 +1,1 @@
+uid://chqja6le1qdhh

--- a/scripts/debug/word_test.gd
+++ b/scripts/debug/word_test.gd
@@ -1,0 +1,570 @@
+extends Node
+
+# Debug helper for validating words and exercising BoardModel without autoloads.
+# Usage (in the running Debug.tscn):
+# var wt = get_tree().get_current_scene().get_node("WordTest")
+# wt.validate_word("hello")
+# wt.place_tile_for_test("A", 7, 7)
+# wt.print_board()
+
+var BoardModel = preload("res://scripts/core/board_model.gd")
+var DictionaryLoader = preload("res://scripts/util/dictionary_loader.gd")
+var TileModelClass = preload("res://scripts/core/tile_model.gd")
+var LETTER_VALUES = {
+	"A":1,"B":3,"C":3,"D":2,"E":1,"F":4,"G":2,"H":4,"I":1,"J":8,"K":5,"L":1,"M":3,
+	"N":1,"O":1,"P":3,"Q":10,"R":1,"S":1,"T":1,"U":1,"V":4,"W":4,"X":8,"Y":4,"Z":10
+}
+
+var board: Node = null
+var dictionary = {}
+var ScoringClass = preload("res://scripts/logic/scoring.gd")
+var scoring = null
+var BoardViewClass = preload("res://scripts/ui/board_view.gd")
+var board_view = null
+
+var last_overall_valid: bool = false
+var last_valid_ranges: Array = []
+
+func _ready():
+	board = BoardModel.new()
+	add_child(board)
+
+	# scoring instance (add as child so its _ready runs and it can add its helpers)
+	scoring = ScoringClass.new()
+	add_child(scoring)
+	# Ensure Debug UI (editor scene) is available before choosing the BoardView.
+	_create_debug_ui()
+
+	# board view (visual) - prefer an editor-provided BoardView under DebugUI
+	var existing_board = _find_debug("BoardView")
+	if existing_board:
+		board_view = existing_board
+	else:
+		board_view = BoardViewClass.new()
+		add_child(board_view)
+
+	board_view.connect("cell_clicked", Callable(self, "_on_board_cell_clicked"))
+	board_view.connect("cell_right_clicked", Callable(self, "_on_board_cell_right_clicked"))
+	var loader = DictionaryLoader.new()
+	dictionary = loader.load_dictionary()
+	print("[word_test] Ready. Dictionary size: ", dictionary.size())
+
+	# Create a small runtime UI so you can click debug helpers when the Evaluator is unavailable.
+	# This is non-destructive: it only adds UI nodes at runtime and does not change scenes on disk.
+	_create_debug_ui()
+
+func validate_word(word: String) -> bool:
+	# GDScript String uses is_empty(); avoid calling non-existent member `empty()`
+	if word.is_empty():
+		return false
+	return dictionary.has(word.to_lower())
+
+func place_tile_for_test(letter: String, x: int, y: int) -> bool:
+	# Create a simple TileModel-like object (use the preloaded TileModelClass)
+	var tile = TileModelClass.new(letter, 1)
+	var grid_pos = Vector2i(x, y)
+	var ok = board.place_tile(tile, grid_pos, true)
+	print("[word_test] place_tile (temp): ", letter, "@", grid_pos, " -> ", ok)
+
+	# After placing, run incremental validation for the current temp placements
+	_run_incremental_validation()
+
+	return ok
+
+func _run_incremental_validation() -> void:
+	var temp_positions = board.get_temp_positions()
+	if temp_positions.size() == 0:
+		print("[word_test] no temp positions")
+		return
+
+	var ranges = board.get_candidate_ranges_for_positions(temp_positions)
+	var combined = board.get_combined_grid_view()
+
+	var any_valid = false
+	var valid_ranges = []
+
+	# Evaluate each candidate range
+	for r in ranges:
+		var s = r.start
+		var e = r.end
+		var word = ""
+		if s.y == e.y:
+			for x in range(s.x, e.x + 1):
+				var t = combined[s.y][x]
+				word += (t.letter if t else "")
+		else:
+			for y in range(s.y, e.y + 1):
+				var t = combined[y][s.x]
+				word += (t.letter if t else "")
+
+		var is_valid = validate_word(word)
+		print("[word_test] candidate: ", word, " -> valid:", is_valid, " range:", s, e)
+		if is_valid:
+			any_valid = true
+			valid_ranges.append(r)
+
+	# Now check that every temp tile is part of at least one valid range
+	var all_temp_covered = true
+	for pos in temp_positions:
+		var covered = false
+		for vr in valid_ranges:
+			var s = vr.start
+			var e = vr.end
+			if s.y == e.y:
+				if pos.y == s.y and pos.x >= s.x and pos.x <= e.x:
+					covered = true
+					break
+			else:
+				if pos.x == s.x and pos.y >= s.y and pos.y <= e.y:
+					covered = true
+					break
+		if not covered:
+			all_temp_covered = false
+			break
+
+	var overall_valid = any_valid and all_temp_covered
+	print("[word_test] incremental validation -> any_valid:", any_valid, " all_temp_covered:", all_temp_covered, " overall_valid:", overall_valid)
+
+	# store last validation state for UI and evaluate button
+	last_overall_valid = overall_valid
+	last_valid_ranges = valid_ranges
+
+	var eval_btn = _find_debug("EvaluateBtn")
+	if eval_btn:
+		eval_btn.disabled = not last_overall_valid
+
+	# update board view visual
+	if board_view:
+		board_view.show_combined_grid(board.get_combined_grid_view(), board.get_temp_positions())
+
+func print_board():
+	# Print combined view (includes temp placements) so debug reflects current placement state
+	var combined = board.get_combined_grid_view()
+	for y in range(combined.size()):
+		var row = ""
+		for x in range(combined[y].size()):
+			var t = combined[y][x]
+			row += (t.letter if t else ".")
+		print(row)
+
+
+func _create_debug_ui() -> void:
+	# Prefer editor-instanced UI: try to instance the saved `DebugUI.tscn` when running.
+	# This makes the debug UI editable in the Godot editor and avoids creating
+	# runtime-only panels. If the saved DebugUI scene is missing, fall back to
+	# a minimal CanvasLayer so the script remains non-destructive.
+	var existing = get_node_or_null("DebugUI")
+	if existing:
+		call_deferred("_finalize_ui_layout")
+		return
+
+	var debug_ui_path = "res://scenes/debug/DebugUI.tscn"
+	if FileAccess.file_exists(debug_ui_path):
+		var packed = load(debug_ui_path)
+		if packed and packed is PackedScene:
+			var inst = packed.instantiate()
+			inst.name = "DebugUI"
+			var scene_root = get_tree().get_current_scene()
+			if scene_root:
+				scene_root.add_child(inst)
+			else:
+				add_child(inst)
+			call_deferred("_finalize_ui_layout")
+			return
+
+	# Fallback: create an empty CanvasLayer so other code can still parent to DebugUI
+	var layer = CanvasLayer.new()
+	layer.name = "DebugUI"
+	var scene_root_fallback = get_tree().get_current_scene()
+	if scene_root_fallback:
+		scene_root_fallback.add_child(layer)
+	else:
+		add_child(layer)
+	call_deferred("_finalize_ui_layout")
+
+func _on_validate_hello() -> void:
+	var ok = validate_word("apple")
+	print("[word_test][ui] validate 'apple' -> ", ok)
+
+func _on_place_A() -> void:
+	place_tile_for_test("A", 7, 7)
+
+func _on_print_board() -> void:
+	print_board()
+
+
+func _on_place_button_pressed() -> void:
+	var letter_node = _find_debug("LetterInput")
+	var x_node = _find_debug("XInput")
+	var y_node = _find_debug("YInput")
+	if not letter_node or not x_node or not y_node:
+		print("[word_test][ui] place inputs not found")
+		return
+	var letter = letter_node.text.strip_edges().to_upper()
+	var xs = x_node.text.strip_edges()
+	var ys = y_node.text.strip_edges()
+	if letter == "" or xs == "" or ys == "":
+		print("[word_test][ui] place: missing input")
+		return
+	var x = int(xs)
+	var y = int(ys)
+	place_tile_for_test(letter, x, y)
+	# update Evaluate button state
+	var eval_btn = _find_debug("EvaluateBtn")
+	if eval_btn:
+		eval_btn.disabled = not last_overall_valid
+
+	if board_view:
+		board_view.show_combined_grid(board.get_combined_grid_view(), board.get_temp_positions())
+
+
+func _on_letter_changed(new_text: String) -> void:
+	var s = "A"
+	if new_text.strip_edges() != "":
+		s = new_text.strip_edges().to_upper()[0]
+	var lbl = _find_debug("SelectedLetterLabel")
+	if lbl:
+		lbl.text = "Selected: " + str(s)
+
+
+func _on_remove_button_pressed() -> void:
+	var x_node = _find_debug("XInput")
+	var y_node = _find_debug("YInput")
+	if not x_node or not y_node:
+		print("[word_test][ui] remove inputs not found")
+		return
+	var xs = x_node.text.strip_edges()
+	var ys = y_node.text.strip_edges()
+	if xs == "" or ys == "":
+		print("[word_test][ui] remove: missing input")
+		return
+	var pos = Vector2i(int(xs), int(ys))
+	board.remove_temp_tile(pos)
+	print("[word_test] removed temp tile at", pos)
+	_run_incremental_validation()
+	print_board()
+	if board_view:
+		board_view.show_combined_grid(board.get_combined_grid_view(), board.get_temp_positions())
+	var eval_btn = _find_debug("EvaluateBtn")
+	if eval_btn:
+		eval_btn.disabled = not last_overall_valid
+
+
+func _on_remove_all_pressed() -> void:
+	board.clear_temp_tiles()
+	print("[word_test] cleared all temp tiles")
+	_run_incremental_validation()
+	print_board()
+	var eval_btn = _find_debug("EvaluateBtn")
+	if eval_btn:
+		eval_btn.disabled = true
+	if board_view:
+		board_view.show_combined_grid(board.get_combined_grid_view(), board.get_temp_positions())
+
+
+func _on_evaluate_pressed() -> void:
+	# Only allow evaluate if last validation said overall_valid
+	if not last_overall_valid:
+		print("[word_test] evaluate: current placement is not valid")
+		return
+
+	var combined = board.get_combined_grid_view()
+	var breakdown = scoring.evaluate_board_with_breakdown(combined)
+	print("[word_test] scoring breakdown:")
+	print(breakdown)
+
+	# Commit temp tiles as the score is being accepted (use turn 0 for debug)
+	board.commit_temp_tiles(0)
+	print("[word_test] committed temp tiles")
+	print_board()
+	# Clear last validation
+	last_overall_valid = false
+	last_valid_ranges = []
+	var eval_btn = _find_debug("EvaluateBtn")
+	if eval_btn:
+		eval_btn.disabled = true
+	if board_view:
+		board_view.show_combined_grid(board.get_combined_grid_view(), board.get_temp_positions())
+
+
+func _on_check_word_pressed() -> void:
+	var input_node = _find_debug("WordInput")
+	if input_node:
+		var w = input_node.text.strip_edges()
+		var ok = validate_word(w)
+		print("[word_test][ui] validate '", w, "' -> ", ok)
+		# Score the typed word using TileModel and LETTER_VALUES (no board multipliers)
+		var score = _score_word_string(w)
+		print("[word_test][ui] score for '", w, "' -> ", score)
+	else:
+		print("[word_test][ui] input node not found")
+
+
+func _on_board_cell_clicked(pos: Vector2i) -> void:
+	# Place a tile at the clicked position using the letter from the UI (or default 'A')
+	var letter_node = _find_debug("LetterInput")
+	var letter = "A"
+	if letter_node:
+		var text = letter_node.text.strip_edges()
+		if text != "":
+			letter = text.to_upper()[0]
+
+	place_tile_for_test(str(letter), pos.x, pos.y)
+
+	var eval_btn = _find_debug("EvaluateBtn")
+	if eval_btn:
+		eval_btn.disabled = not last_overall_valid
+
+	if board_view:
+		board_view.show_combined_grid(board.get_combined_grid_view(), board.get_temp_positions())
+
+
+func _on_alphabet_pressed(letter: String) -> void:
+	# Set the LetterInput LineEdit and update SelectedLetterLabel
+	var letter_node = _find_debug("LetterInput")
+	if letter_node and letter_node is LineEdit:
+		letter_node.text = str(letter)
+	var lbl = _find_debug("SelectedLetterLabel")
+	if lbl and lbl is Label:
+		lbl.text = "Selected: " + str(letter)
+
+
+func _on_board_cell_right_clicked(pos: Vector2i) -> void:
+	# Right-click removes a temp tile at the clicked position
+	board.remove_temp_tile(pos)
+	_run_incremental_validation()
+
+	if board_view:
+		board_view.show_combined_grid(board.get_combined_grid_view(), board.get_temp_positions())
+
+	var eval_btn = _find_debug("EvaluateBtn")
+	if eval_btn:
+		eval_btn.disabled = not last_overall_valid
+
+
+func _score_word_string(word: String) -> int:
+	if word.strip_edges().is_empty():
+		return 0
+	var total = 0
+	# create TileModel instances and sum effective_letter_value
+	var placement_multiplier_sum = 0
+	for i in word.to_upper().split(""):
+		if i == "":
+			continue
+		var ch = i
+		var base = LETTER_VALUES.get(ch, 0)
+		var tile = TileModelClass.new(ch, base)
+		total += tile.effective_letter_value()
+		placement_multiplier_sum += tile.placement_multiplier
+	# Final multiplier comes from tiles themselves (sum of placement_multiplier)
+	var final_mul = max(1, placement_multiplier_sum)
+	return total * final_mul
+
+
+func _on_viewport_resized() -> void:
+	var vp = get_viewport()
+	if not vp:
+		return
+	var size = vp.get_visible_rect().size
+	var bottom_lbl = _find_debug("BottomHelp")
+	if bottom_lbl:
+		bottom_lbl.position = Vector2(10, size.y - 36)
+
+	var panel = _find_debug("DebugPanel")
+	if panel and board_view:
+		var bx = panel.position.x + panel.size.x + 20
+		var by = panel.position.y + 20
+		board_view.position = Vector2(bx, by)
+
+	# deferred layout finalizer (safe to call any time)
+func _finalize_ui_layout() -> void:
+	var scene_root = get_tree().get_current_scene()
+	var ui_root = null
+	if scene_root:
+		ui_root = scene_root.get_node_or_null("DebugUI")
+	if not ui_root:
+		ui_root = get_node_or_null("DebugUI")
+	if not ui_root:
+		return
+	var layer = ui_root
+	var panel = null
+	if ui_root.has_node("DebugPanel"):
+		panel = ui_root.get_node("DebugPanel")
+
+	# compute board size reliably; fallback to exported cols/cell_size
+	var board_size = Vector2(0, 0)
+	if board_view:
+		board_size = board_view.size
+	if board_size == Vector2.ZERO and board_view and board_view.has_method("get_children"):
+		# try exported properties
+		var cols = 0
+		var rows = 0
+		var cell_size = 48
+		if board_view.has_meta("cols") or ("cols" in board_view):
+			cols = board_view.cols if "cols" in board_view else 0
+		if board_view.has_meta("rows") or ("rows" in board_view):
+			rows = board_view.rows if "rows" in board_view else 0
+		if board_view.has_meta("cell_size") or ("cell_size" in board_view):
+			cell_size = board_view.cell_size if "cell_size" in board_view else cell_size
+		if cols > 0 and rows > 0:
+			board_size = Vector2(cols * cell_size, rows * cell_size)
+
+	# Right placement panel: prefer an editor-provided child under DebugUI.
+	var placement_panel = null
+	if ui_root.has_node("PlacementPanel"):
+		placement_panel = ui_root.get_node("PlacementPanel")
+
+	# position it to the right of the board_view (fallback to panel if board_view missing)
+	var board_pos = Vector2(10, 10)
+	if panel:
+		board_pos = Vector2(panel.position.x + panel.size.x + 20, panel.position.y + 10)
+	elif board_view:
+		board_pos = Vector2(board_view.position.x + board_size.x + 16, 10)
+
+	if placement_panel:
+		placement_panel.position = board_pos
+		if panel:
+			placement_panel.position.y = panel.position.y + (panel.size.y - placement_panel.size.y) * 0.5
+
+	# Move the existing PlaceRow into the placement panel if present
+	var old_place = null
+	if ui_root.has_node("DebugPanel/DebugVBox/MainHBox/RightPlacement/PlaceRow"):
+		old_place = ui_root.get_node("DebugPanel/DebugVBox/MainHBox/RightPlacement/PlaceRow")
+	if old_place and old_place.get_parent() and placement_panel:
+		old_place.get_parent().remove_child(old_place)
+		placement_panel.add_child(old_place)
+
+	# Left action panel: expect editor-inserted `LeftActionPanel` under DebugUI.
+	var left_panel = null
+	if ui_root.has_node("LeftActionPanel"):
+		left_panel = ui_root.get_node("LeftActionPanel")
+	if left_panel and panel:
+		left_panel.position = Vector2(panel.position.x + 6, panel.position.y + (panel.size.y - left_panel.size.y) * 0.5)
+
+	var old_left = null
+	if ui_root.has_node("DebugPanel/DebugVBox/MainHBox/LeftActions"):
+		old_left = ui_root.get_node("DebugPanel/DebugVBox/MainHBox/LeftActions")
+	if old_left and old_left.get_parent() and left_panel:
+		old_left.get_parent().remove_child(old_left)
+		left_panel.add_child(old_left)
+
+	# Remove the original (now-empty) RightPlacement container if present
+	var old_right = null
+	if ui_root.has_node("DebugPanel/DebugVBox/MainHBox/RightPlacement"):
+		old_right = ui_root.get_node("DebugPanel/DebugVBox/MainHBox/RightPlacement")
+	if old_right and old_right.get_parent():
+		old_right.get_parent().remove_child(old_right)
+		old_right.queue_free()
+
+	# Wire controls for any panels we found/instantiated
+	_wire_ui_controls(layer)
+
+
+func _wire_ui_controls(ui_root: Node) -> void:
+	if not ui_root:
+		return
+
+
+	# Debug: list ui_root children and expected controls for verification
+	var child_names: Array = []
+	for c in ui_root.get_children():
+		child_names.append(c.name)
+	print("[word_test][ui] wiring under:", ui_root, " children:", child_names)
+
+	var expected_controls = ["LetterInput", "Check", "Validate", "PlaceA", "Print", "RemoveAll", "EvaluateBtn", "Place", "Remove", "SelectedLetterLabel", "XInput", "YInput", "WordInput"]
+	for en in expected_controls:
+		var found = _find_descendant(ui_root, en)
+		print("[word_test][ui] lookup ->", en, "->", (found != null))
+
+	# Connect lineedit text_changed
+	var letter_le = _find_descendant(ui_root, "LetterInput")
+	if letter_le and letter_le is LineEdit:
+		if not letter_le.is_connected("text_changed", Callable(self, "_on_letter_changed")):
+			letter_le.connect("text_changed", Callable(self, "_on_letter_changed"))
+
+	# Connect WordInput check button (Check) if present
+	_connect_pressed(ui_root, "Check", "_on_check_word_pressed")
+	_connect_pressed(ui_root, "Validate", "_on_validate_hello")
+	_connect_pressed(ui_root, "PlaceA", "_on_place_A")
+	_connect_pressed(ui_root, "Print", "_on_print_board")
+	_connect_pressed(ui_root, "RemoveAll", "_on_remove_all_pressed")
+	_connect_pressed(ui_root, "EvaluateBtn", "_on_evaluate_pressed")
+	# Placement controls
+	_connect_pressed(ui_root, "Place", "_on_place_button_pressed")
+	_connect_pressed(ui_root, "Remove", "_on_remove_button_pressed")
+
+	# Ensure Evaluate button disabled state matches last validation
+	var eval_btn = _find_descendant(ui_root, "EvaluateBtn")
+	if eval_btn and eval_btn is Button:
+		eval_btn.disabled = not last_overall_valid
+
+	# Alphabet mini-keyboard: create buttons A-Z under LeftActionPanel if not present
+	var left_panel = _find_descendant(ui_root, "LeftActionPanel")
+	if left_panel:
+		var alpha = _find_descendant(left_panel, "Alphabet")
+		if not alpha:
+			alpha = GridContainer.new()
+			alpha.name = "Alphabet"
+			alpha.columns = 7
+			left_panel.add_child(alpha)
+			# Create buttons A-Z
+			for i in range(26):
+				var ch = char(65 + i) # ASCII A..Z
+				var b = Button.new()
+				b.name = "Key_" + ch
+				b.text = ch
+				b.custom_minimum_size = Vector2(28, 28)
+				# connect pressed with bound letter
+				b.connect("pressed", Callable(self, "_on_alphabet_pressed").bind(ch))
+				alpha.add_child(b)
+
+
+func _find_descendant(root: Node, target_name: String) -> Node:
+	if not root:
+			return null
+	# simple BFS
+	var q: Array = [root]
+	while q.size() > 0:
+		var n = q.pop_front()
+		if _node_name_matches(n.name, target_name):
+			return n
+		for c in n.get_children():
+			q.append(c)
+	return null
+
+
+func _node_name_matches(node_name: String, target_name: String) -> bool:
+	# Match exact name or names that include prefixes like 'DebugUI#LeftActionPanel'
+	if node_name == target_name:
+		return true
+	# Some exported/instanced nodes in the editor show up with prefixes like 'Parent#Child'
+	# so match by suffix as a fallback.
+	if node_name.ends_with("#" + target_name):
+		return true
+	if node_name.ends_with(target_name):
+		return true
+	return false
+
+
+func _find_debug(name: String) -> Node:
+	# Try to find DebugUI under the current scene root first, then fall back to
+	# this node's children. This allows DebugUI to be instanced at the scene
+	# root (preferred) while keeping backwards compatibility.
+	var scene_root = get_tree().get_current_scene()
+	var ui = null
+	if scene_root:
+		ui = scene_root.get_node_or_null("DebugUI")
+	if not ui:
+		ui = get_node_or_null("DebugUI")
+	if not ui:
+		return null
+	return _find_descendant(ui, name)
+
+
+func _connect_pressed(ui_root: Node, node_name: String, method_name: String) -> void:
+	if not ui_root:
+		return
+	var b = _find_descendant(ui_root, node_name)
+	if b and b is Button:
+		if not b.is_connected("pressed", Callable(self, method_name)):
+			b.connect("pressed", Callable(self, method_name))

--- a/scripts/debug/word_test.gd.uid
+++ b/scripts/debug/word_test.gd.uid
@@ -1,0 +1,1 @@
+uid://byyivub0ihq06

--- a/scripts/logic/scoring.gd
+++ b/scripts/logic/scoring.gd
@@ -1,0 +1,147 @@
+extends Node
+
+# Scoring: Handles word validation and score calculation.
+# Designed to be extensible with new scoring rules.
+
+var _word_finder = preload("res://scripts/logic/word_finder.gd").new()
+var _word_checker = preload("res://scripts/core/word_checker.gd").new()
+var _scoring_rules = []
+
+func _ready():
+	# Add child nodes for script instances to process
+	add_child(_word_finder)
+	add_child(_word_checker)
+	
+	# Register the basic scoring rule (store owner+method to remain compatible across Godot versions)
+	_register_rule(self, "_calculate_basic_word_score")
+	
+	# TODO: Add a public method to register new scoring rules from other scripts.
+	# Example: Scoring.register_rule(funcref(PalindromeScoring, "calculate_score"))
+
+func evaluate_board(grid: Array) -> int:
+	# Backwards-compatible wrapper: return the integer total score (sum of final_score for each word)
+	var breakdown = evaluate_board_with_breakdown(grid)
+	return int(breakdown.get("total_score", 0))
+
+
+func evaluate_board_with_breakdown(grid: Array) -> Dictionary:
+	# Returns a dictionary with per-word breakdowns and total_score.
+	# Each word breakdown contains: base_sum, tile_multiplier_sum, board_multiplier_sum, final_score
+	var found_words = _word_finder.find_words(grid)
+	var words = []
+	var total_score = 0
+
+	for word_info in found_words:
+		if _word_checker.is_valid_word(word_info["word"]):
+			var breakdown = _calculate_word_score(word_info, grid)
+			words.append(breakdown)
+			total_score += int(breakdown.get("final_score", 0))
+
+	return {"total_score": total_score, "words": words}
+
+
+func _process_cell(cell) -> Array:
+	# Returns [cell_base, cell_tile_mul, cell_board_mul]
+	var cell_base = 0.0
+	var cell_tile_mul = 1.0
+	var cell_board_mul = 1.0
+
+	if cell == null:
+		return [cell_base, cell_tile_mul, cell_board_mul]
+
+	# If the cell is a TileModel instance (declared via class_name TileModel)
+	if typeof(cell) == TYPE_OBJECT and cell is TileModel:
+		cell_base = float(cell.effective_letter_value())
+		cell_tile_mul = float(cell.placement_multiplier)
+		return [cell_base, cell_tile_mul, cell_board_mul]
+
+	# If the grid stores a dictionary with explicit fields
+	if typeof(cell) == TYPE_DICTIONARY:
+		cell_base = float(cell.get("value", 0))
+		cell_tile_mul = float(cell.get("placement_multiplier", 1))
+		cell_board_mul = float(cell.get("board_multiplier", 1))
+		return [cell_base, cell_tile_mul, cell_board_mul]
+
+	# Fallback: try to read a .value property if present
+	if typeof(cell) == TYPE_OBJECT and cell.has_method("get"):
+		# many Godot objects implement get(property) — try value
+		var v = cell.get("value")
+		if v != null:
+			cell_base = float(v)
+
+	return [cell_base, cell_tile_mul, cell_board_mul]
+
+
+func _calculate_word_score(word_info: Dictionary, grid: Array) -> Dictionary:
+	# Implements the requested formula:
+	# final_score = sum_of_tiles_multipliers * sum_of_tiles_base_score * sum_of_relevant_board_multipliers
+	var base_sum: float = 0.0
+	var tile_multiplier_sum: float = 0.0
+	var board_multiplier_sum: float = 0.0
+
+	var word = word_info.get("word", "")
+	var start = word_info.get("start")
+	var end = word_info.get("end")
+
+	# traverse positions
+
+	# traverse positions
+	if start == null or end == null:
+		return {"word": word, "base_sum": 0, "tile_multiplier_sum": 0, "board_multiplier_sum": 0, "final_score": 0}
+
+	if start.y == end.y: # Horizontal
+		for x in range(start.x, end.x + 1):
+			var cell = grid[start.y][x]
+			var vals = _process_cell(cell)
+			base_sum += vals[0]
+			tile_multiplier_sum += vals[1]
+			board_multiplier_sum += vals[2]
+	else: # Vertical
+		for y in range(start.y, end.y + 1):
+			var cell = grid[y][start.x]
+			var vals = _process_cell(cell)
+			base_sum += vals[0]
+			tile_multiplier_sum += vals[1]
+			board_multiplier_sum += vals[2]
+
+	# Ensure sensible minimums to avoid zeroing out a score unexpectedly
+	tile_multiplier_sum = max(1.0, tile_multiplier_sum)
+	board_multiplier_sum = max(1.0, board_multiplier_sum)
+
+	var final_score = base_sum * tile_multiplier_sum * board_multiplier_sum
+
+	return {
+		"word": word,
+		"base_sum": int(base_sum),
+		"tile_multiplier_sum": tile_multiplier_sum,
+		"board_multiplier_sum": board_multiplier_sum,
+		"final_score": int(final_score)
+	}
+
+func _register_rule(owner, method_name: String):
+	# Store rules as a small dict so we avoid relying on FuncRef/Callable types
+	_scoring_rules.append({"owner": owner, "method": method_name})
+
+# --- Scoring Rule Implementations ---
+
+func _calculate_basic_word_score(word_info: Dictionary, grid: Array) -> int:
+	# Basic score is the sum of the values of the tiles in the word.
+	var score = 0
+	var word = word_info["word"]
+	var start = word_info["start"]
+	var end = word_info["end"]
+	
+	if start.y == end.y: # Horizontal word
+		for x in range(start.x, end.x + 1):
+			score += grid[start.y][x].value
+	else: # Vertical word
+		for y in range(start.y, end.y + 1):
+			score += grid[y][start.x].value
+			
+	return score
+
+# --- TODO: Future Extensibility Examples ---
+# func _calculate_palindrome_bonus(word_info, grid):
+#     if word_info["word"] == word_info["word"].reverse():
+#         return _calculate_basic_word_score(word_info, grid) * 2 # Triple the base score
+#     return 0

--- a/scripts/logic/scoring.gd.uid
+++ b/scripts/logic/scoring.gd.uid
@@ -1,0 +1,1 @@
+uid://cllcqm7lxbr2i

--- a/scripts/logic/turn_manager.gd
+++ b/scripts/logic/turn_manager.gd
@@ -1,0 +1,14 @@
+extends Node
+
+# TurnManager: Manages the state of turns, including the current turn number.
+
+var _current_turn = 0
+
+func get_current_turn() -> int:
+	return _current_turn
+
+func next_turn():
+	_current_turn += 1
+
+func reset():
+	_current_turn = 0

--- a/scripts/logic/turn_manager.gd.uid
+++ b/scripts/logic/turn_manager.gd.uid
@@ -1,0 +1,1 @@
+uid://ce5xlah786tub

--- a/scripts/logic/word_finder.gd
+++ b/scripts/logic/word_finder.gd
@@ -1,0 +1,47 @@
+extends Node
+
+# WordFinder: Scans the board to find all horizontal and vertical words.
+
+func find_words(grid: Array) -> Array:
+	var found_words = []
+	if grid.is_empty() or grid[0].is_empty():
+		return found_words
+
+	var height = grid.size()
+	var width = grid[0].size()
+
+	# Scan rows for horizontal words
+	for y in range(height):
+		var current_word = ""
+		var start_pos = Vector2i(-1, y)
+		for x in range(width):
+			var tile = grid[y][x]
+			if tile:
+				if current_word.is_empty():
+					start_pos.x = x
+				current_word += tile.letter
+			else:
+				if current_word.length() > 1:
+					found_words.append({"word": current_word, "start": start_pos, "end": Vector2i(x - 1, y)})
+				current_word = ""
+		if current_word.length() > 1:
+			found_words.append({"word": current_word, "start": start_pos, "end": Vector2i(width - 1, y)})
+
+	# Scan columns for vertical words
+	for x in range(width):
+		var current_word = ""
+		var start_pos = Vector2i(x, -1)
+		for y in range(height):
+			var tile = grid[y][x]
+			if tile:
+				if current_word.is_empty():
+					start_pos.y = y
+				current_word += tile.letter
+			else:
+				if current_word.length() > 1:
+					found_words.append({"word": current_word, "start": start_pos, "end": Vector2i(x, y - 1)})
+				current_word = ""
+		if current_word.length() > 1:
+			found_words.append({"word": current_word, "start": start_pos, "end": Vector2i(x, height - 1)})
+			
+	return found_words

--- a/scripts/logic/word_finder.gd.uid
+++ b/scripts/logic/word_finder.gd.uid
@@ -1,0 +1,1 @@
+uid://bb242mdribl4w

--- a/scripts/ui/board_view.gd
+++ b/scripts/ui/board_view.gd
@@ -1,0 +1,77 @@
+extends Control
+
+signal cell_clicked(pos)
+signal cell_right_clicked(pos)
+
+@export var cols: int = 11
+@export var rows: int = 11
+@export var cell_size: int = 48
+
+@onready var grid_container: GridContainer = null
+# Avoid shadowing the global `TileModel` class_name; use a different variable name
+var TileModelClass = preload("res://scripts/core/tile_model.gd")
+
+func _ready():
+	size = Vector2(cols * cell_size, rows * cell_size)
+	# Do not auto-center here; let the parent (debug UI) decide placement.
+	grid_container = GridContainer.new()
+	grid_container.columns = cols
+	add_child(grid_container)
+	_build_cells()
+
+func _build_cells() -> void:
+	# remove existing children if any
+	for c in grid_container.get_children():
+		c.queue_free()
+	
+	for y in range(rows):
+		for x in range(cols):
+			var btn = Button.new()
+			btn.name = str(x) + "," + str(y)
+			btn.text = ""
+			btn.toggle_mode = false
+			btn.custom_minimum_size = Vector2(cell_size, cell_size)
+			# connect pressed with bound position
+			var c_pressed = Callable(self, "_on_cell_pressed").bind(Vector2i(x, y))
+			btn.connect("pressed", c_pressed)
+			var c_gui = Callable(self, "_on_cell_gui_input").bind(Vector2i(x, y))
+			btn.connect("gui_input", c_gui)
+			grid_container.add_child(btn)
+
+func _on_cell_pressed(pos: Vector2i) -> void:
+	emit_signal("cell_clicked", pos)
+
+func _on_cell_gui_input(event: InputEvent, pos: Vector2i) -> void:
+	if event is InputEventMouseButton:
+		if event.button_index == MOUSE_BUTTON_RIGHT and event.pressed:
+			emit_signal("cell_right_clicked", pos)
+
+func show_combined_grid(grid_view: Array, temp_positions: Array = []) -> void:
+	# grid_view is a 2D array [row][col]
+	# temp_positions is an array of Vector2i
+	var temp_set = {}
+	for p in temp_positions:
+		temp_set[str(p.x) + "," + str(p.y)] = true
+	
+	var idx = 0
+	for y in range(rows):
+		for x in range(cols):
+			var btn = grid_container.get_child(idx)
+			var tile = null
+			if y < grid_view.size() and x < grid_view[y].size():
+				tile = grid_view[y][x]
+			if tile != null:
+				# show letter on button
+					if typeof(tile) == TYPE_OBJECT and tile is TileModel:
+						btn.text = str(tile.letter)
+					else:
+						btn.text = str(tile)
+			else:
+				btn.text = ""
+			# highlight temp placements
+			var key = str(x) + "," + str(y)
+			if temp_set.has(key):
+				btn.modulate = Color(0.8, 1.0, 0.8)
+			else:
+				btn.modulate = Color(1, 1, 1)
+			idx += 1

--- a/scripts/ui/board_view.gd.uid
+++ b/scripts/ui/board_view.gd.uid
@@ -1,0 +1,1 @@
+uid://dh3lvohnungoq

--- a/scripts/util/dictionary_loader.gd
+++ b/scripts/util/dictionary_loader.gd
@@ -1,0 +1,20 @@
+extends Node
+
+# DictionaryLoader: Loads the english_words.txt file into a HashSet for fast lookups.
+
+const DICTIONARY_PATH = "res://data/english_words.txt"
+
+func load_dictionary() -> Dictionary:
+	var dictionary = {}
+	var file = FileAccess.open(DICTIONARY_PATH, FileAccess.READ)
+	if not file:
+		printerr("Dictionary file not found at path: ", DICTIONARY_PATH)
+		return dictionary
+
+	while not file.eof_reached():
+		var word = file.get_line().strip_edges()
+		if not word.is_empty():
+			dictionary[word] = true
+	
+	file.close()
+	return dictionary

--- a/scripts/util/dictionary_loader.gd.uid
+++ b/scripts/util/dictionary_loader.gd.uid
@@ -1,0 +1,1 @@
+uid://bojthfa28h5pf

--- a/scripts/util/random_letter_generator.gd
+++ b/scripts/util/random_letter_generator.gd
@@ -1,0 +1,4 @@
+extends Node
+
+# RandomLetterGenerator: Generates random letters for the TileBag.
+# TODO: Implement letter generation, possibly with weights.

--- a/scripts/util/random_letter_generator.gd.uid
+++ b/scripts/util/random_letter_generator.gd.uid
@@ -1,0 +1,1 @@
+uid://c0n8kq6nsreba


### PR DESCRIPTION
This pull request introduces the foundational architecture and initial implementation for a Godot 4 Scrabble-like game ("Wordatro"). It establishes key autoload singletons, core game logic, board and tile management, and supporting files for debugging and developer onboarding. The changes are grouped below by theme:

**Core Architecture and Game Loop**

* Added autoload singletons: `EventBus`, `GameManager`, and `TileBag`, each with their own scripts and UID files for Godot autoload registration. These provide decoupled signal-based communication, main game loop control, and tile generation, respectively (`autoload/event_bus.gd`, `autoload/event_bus.gd.uid`, `autoload/game_manager.gd`, `autoload/game_manager.gd.uid`, `autoload/tile_bag.gd`, `autoload/tile_bag.gd.uid`). [[1]](diffhunk://#diff-9ddfddc202bcd66b90ba898672236811349d70732940c65b1c0edf1c0cbb0aa0R1-R9) [[2]](diffhunk://#diff-8c69b521a38d4b63d39352ec995ee46ef25c9e9fb52cacb242664fe5218f917dR1) [[3]](diffhunk://#diff-2e56b2f2bd9cc245264688eacd508208cceda14fb94a84da51ee7a2ec2394dd8R1-R85) [[4]](diffhunk://#diff-a257119e5d4b3184268925689ed970d2c82d13d961faed10f4d2b464e75650e2R1) [[5]](diffhunk://#diff-190ffd39c6873bb1d366c1e8b17f979cf2edd49a918e32b7ed0b8446fcf4dee6R1-R53) [[6]](diffhunk://#diff-894f455a624c8fc52a4813a800e83a8e2c41c3b2c0bedcfdb798b852369945a4R1)
* Implemented the main game loop and turn management in `GameManager`, including turn progression, tile drawing, provisional scoring, and game end logic. Signals are used to notify other systems of game events.

**Board and Tile Management**

* Added a visual board scene (`scenes/board/Board.tscn`) and its script (`scenes/board/board.gd`) to handle grid-to-world conversions, tile snapping, and grid validation. [[1]](diffhunk://#diff-b567796c7d4d767309c052fee01a054b800b35173338a0fece39457f328fd95cR1-R6) [[2]](diffhunk://#diff-9fc1dc164a6e1c493b727b4a06dc8e323bf06b26d89fd6df8eb520b3b2d8f6feR1-R37)
* Implemented `TileBag` logic for generating tiles based on Scrabble distributions and emitting signals when tiles are drawn.

**Debugging and Developer Support**

* Added a debug scene (`scenes/debug/Debug.tscn`) and supporting script for runtime testing and word validation.
* Created session progress and implementation plan documentation in `.github/session_progress.md`, outlining completed work, debugging helpers, and next development steps.

**Project Configuration and Onboarding**

* Updated `project.godot` to register autoloads, set the main scene, and configure display settings; provided backup files for safe recovery. [[1]](diffhunk://#diff-88c173602c6c7ccaaba6f408d21c235bda4d6884e30e71e73e1b07b9f93ad7b6L13-R30) [[2]](diffhunk://#diff-3ff9883ece735780926e0c2c301f70ce35007da4f1a137dfa7dca9f5b1379c81R1-R44) [[3]](diffhunk://#diff-e208ac4c649c3e989fe33a78e5d62b4557857abdd74dd93e7c6976a7d30ea757R1-R37)
* Added `.editorconfig` for consistent code formatting, especially for `.gd` and `.tscn` files.
* Included `.github/copilot-instructions.md` to document architecture, conventions, and extension points for AI coding agents and new contributors.

**Supporting Assets**

* Added a small English word dictionary for validation and gameplay in `data/english_words.txt`.

These changes collectively establish the baseline for further feature development, debugging, and team onboarding.