### PR TITLE
gitignore

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,41 @@
 # Normalize EOL for all files that Git considers text files.
 * text=auto eol=lf
+
+# Git LFS Tracking (Assets)
+
+# 3D Models
+*.fbx filter=lfs diff=lfs merge=lfs -text
+*.gltf filter=lfs diff=lfs merge=lfs -text
+*.glb filter=lfs diff=lfs merge=lfs -text
+*.blend filter=lfs diff=lfs merge=lfs -text
+*.obj filter=lfs diff=lfs merge=lfs -text
+
+# Images
+*.png filter=lfs diff=lfs merge=lfs -text
+*.svg filter=lfs diff=lfs merge=lfs -text
+*.jpg filter=lfs diff=lfs merge=lfs -text
+*.jpeg filter=lfs diff=lfs merge=lfs -text
+*.gif filter=lfs diff=lfs merge=lfs -text
+*.tga filter=lfs diff=lfs merge=lfs -text
+*.webp filter=lfs diff=lfs merge=lfs -text
+*.exr filter=lfs diff=lfs merge=lfs -text
+*.hdr filter=lfs diff=lfs merge=lfs -text
+*.dds filter=lfs diff=lfs merge=lfs -text
+
+# Audio
+*.mp3 filter=lfs diff=lfs merge=lfs -text
+*.wav filter=lfs diff=lfs merge=lfs -text
+*.ogg filter=lfs diff=lfs merge=lfs -text
+
+# Font & Icon
+*.ttf filter=lfs diff=lfs merge=lfs -text
+*.otf filter=lfs diff=lfs merge=lfs -text
+*.ico filter=lfs diff=lfs merge=lfs -text
+
+# Godot LFS Specific
+*.scn filter=lfs diff=lfs merge=lfs -text
+*.res filter=lfs diff=lfs merge=lfs -text
+*.material filter=lfs diff=lfs merge=lfs -text
+*.anim filter=lfs diff=lfs merge=lfs -text
+*.mesh filter=lfs diff=lfs merge=lfs -text
+*.lmbake filter=lfs diff=lfs merge=lfs -text

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Godot 4+ specific ignores
 .godot/
+/android/
 .nomedia
 
 # Godot-specific ignores

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,17 @@
 # Godot 4+ specific ignores
 .godot/
-/android/
+.nomedia
+
+# Godot-specific ignores
+.import/
+export.cfg
+export_credentials.cfg
+*.tmp
+*~
+# Imported translations (automatically generated from CSV files)
+*.translation
+
+# Mono-specific ignores
+.mono/
+data_*/
+mono_crash.*.json


### PR DESCRIPTION
Add comprehensive Git LFS tracking for various asset types including 3D models, images, audio files, fonts, and Godot-specific file formats. Expand gitignore to include Godot-specific directories and files like .import/, .mono/, export configurations, and temporary files.

This improves repository performance by properly handling large binary files and prevents unnecessary files from being committed.