### PR TITLE
multi-select

### DIFF
--- a/autoload/event_bus.gd
+++ b/autoload/event_bus.gd
@@ -127,3 +127,19 @@ signal ui_refresh_requested()
 
 ## Emitted when a notification should be shown.
 signal notification_requested(message: String, type: String)
+
+# =============================================================================
+# SELECTION EVENTS
+# =============================================================================
+
+## Emitted when selection mode changes (single <-> multi).
+signal selection_mode_changed(is_multi_select: bool)
+
+## Emitted when selection changes.
+signal selection_changed(selected_tiles: Array)
+
+## Emitted when multi-tile drag starts.
+signal multi_drag_started(tiles: Array)
+
+## Emitted when multi-tile drag ends.
+signal multi_drag_ended(tiles: Array, success: bool)

--- a/autoload/hand_manager.gd
+++ b/autoload/hand_manager.gd
@@ -222,5 +222,8 @@ func _connect_tile_signals(tile: Tile) -> void:
 	if not tile.tile_right_clicked.is_connected(_main_scene._on_tile_right_clicked):
 		tile.tile_right_clicked.connect(_main_scene._on_tile_right_clicked)
 
+	if not tile.tile_drag_started.is_connected(_main_scene._on_tile_drag_started):
+		tile.tile_drag_started.connect(_main_scene._on_tile_drag_started)
+
 	if not tile.tile_drag_ended.is_connected(_main_scene._on_tile_drag_ended):
 		tile.tile_drag_ended.connect(_main_scene._on_tile_drag_ended)

--- a/autoload/selection_manager.gd
+++ b/autoload/selection_manager.gd
@@ -1,0 +1,165 @@
+extends Node
+
+## SelectionManager: Central source of truth for tile selection state and mode.
+## Manages single/multi-select modes and maintains ordered selection.
+
+# =============================================================================
+# ENUMS
+# =============================================================================
+
+enum SelectionMode {
+	SINGLE,  # Clicking a tile deselects all others first
+	MULTI    # Clicking toggles tile selection, order preserved
+}
+
+# =============================================================================
+# STATE
+# =============================================================================
+
+var mode: SelectionMode = SelectionMode.SINGLE
+var _selected_tiles: Array[Tile] = []  # Ordered by selection time
+
+# =============================================================================
+# MODE MANAGEMENT
+# =============================================================================
+
+## Toggles between single and multi-select modes.
+func toggle_mode() -> void:
+	if mode == SelectionMode.SINGLE:
+		set_mode(SelectionMode.MULTI)
+	else:
+		set_mode(SelectionMode.SINGLE)
+
+
+## Sets the selection mode explicitly.
+func set_mode(new_mode: SelectionMode) -> void:
+	if mode == new_mode:
+		return
+
+	var was_multi: bool = mode == SelectionMode.MULTI
+	mode = new_mode
+
+	# Leaving multi-select mode deselects all tiles
+	if was_multi and mode == SelectionMode.SINGLE:
+		deselect_all()
+
+	EventBus.selection_mode_changed.emit(is_multi_select_enabled())
+	print("[SelectionManager] Mode changed to: %s" % SelectionMode.keys()[mode])
+
+
+## Returns true if multi-select mode is enabled.
+func is_multi_select_enabled() -> bool:
+	return mode == SelectionMode.MULTI
+
+# =============================================================================
+# SELECTION OPERATIONS
+# =============================================================================
+
+## Selects a tile (mode-aware behavior).
+func select_tile(tile: Tile) -> void:
+	if tile == null:
+		return
+
+	match mode:
+		SelectionMode.SINGLE:
+			_select_single(tile)
+		SelectionMode.MULTI:
+			_toggle_multi(tile)
+
+
+## Deselects a specific tile.
+func deselect_tile(tile: Tile) -> void:
+	if tile == null or tile not in _selected_tiles:
+		return
+
+	_selected_tiles.erase(tile)
+	tile.set_selected(false)
+	tile.set_selection_order(-1)
+
+	# Update order for remaining tiles
+	_update_selection_orders()
+
+	EventBus.selection_changed.emit(get_selected_tiles())
+
+
+## Deselects all tiles.
+func deselect_all() -> void:
+	for tile in _selected_tiles:
+		tile.set_selected(false)
+		tile.set_selection_order(-1)
+
+	_selected_tiles.clear()
+	EventBus.selection_changed.emit([])
+
+
+## Returns the currently selected tiles in selection order.
+func get_selected_tiles() -> Array[Tile]:
+	# Filter out any tiles that may have been freed
+	var valid_tiles: Array[Tile] = []
+	for tile in _selected_tiles:
+		if is_instance_valid(tile):
+			valid_tiles.append(tile)
+
+	if valid_tiles.size() != _selected_tiles.size():
+		_selected_tiles = valid_tiles
+
+	return _selected_tiles.duplicate()
+
+
+## Returns the number of selected tiles.
+func get_selection_count() -> int:
+	return get_selected_tiles().size()
+
+
+## Returns the selection order of a tile (-1 if not selected).
+func get_tile_order(tile: Tile) -> int:
+	if tile == null:
+		return -1
+	return _selected_tiles.find(tile)
+
+
+## Returns true if there are any selected tiles.
+func has_selection() -> bool:
+	return not get_selected_tiles().is_empty()
+
+# =============================================================================
+# PRIVATE HELPERS
+# =============================================================================
+
+func _select_single(tile: Tile) -> void:
+	# If already selected, deselect it
+	if tile in _selected_tiles:
+		deselect_tile(tile)
+		return
+
+	# Deselect all others first
+	for t in _selected_tiles:
+		t.set_selected(false)
+		t.set_selection_order(-1)
+
+	_selected_tiles.clear()
+
+	# Select the new tile
+	_selected_tiles.append(tile)
+	tile.set_selected(true)
+	tile.set_selection_order(0)
+
+	EventBus.selection_changed.emit(get_selected_tiles())
+
+
+func _toggle_multi(tile: Tile) -> void:
+	if tile in _selected_tiles:
+		# Deselect this tile
+		deselect_tile(tile)
+	else:
+		# Add to selection
+		_selected_tiles.append(tile)
+		tile.set_selected(true)
+		tile.set_selection_order(_selected_tiles.size() - 1)
+
+		EventBus.selection_changed.emit(get_selected_tiles())
+
+
+func _update_selection_orders() -> void:
+	for i in _selected_tiles.size():
+		_selected_tiles[i].set_selection_order(i)

--- a/autoload/selection_manager.gd.uid
+++ b/autoload/selection_manager.gd.uid
@@ -1,0 +1,1 @@
+uid://d10ef2y56hboj

--- a/project.godot
+++ b/project.godot
@@ -22,10 +22,19 @@ GameManager="*res://autoload/game_manager.gd"
 DebugManager="*res://autoload/debug_manager.gd"
 TileBag="*res://autoload/tile_bag.gd"
 HandManager="*res://autoload/hand_manager.gd"
+SelectionManager="*res://autoload/selection_manager.gd"
 
 [dotnet]
 
 project/assembly_name="Wordatro"
+
+[input]
+
+toggle_multi_select={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":81,"physical_keycode":0,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+]
+}
 
 [rendering]
 

--- a/scenes/Debug/debug_console.gd.uid
+++ b/scenes/Debug/debug_console.gd.uid
@@ -1,0 +1,1 @@
+uid://bquiih7ch3gv4

--- a/scenes/Main.tscn
+++ b/scenes/Main.tscn
@@ -1,9 +1,10 @@
-[gd_scene load_steps=5 format=3 uid="uid://ddchieu337gsy"]
+[gd_scene load_steps=6 format=3 uid="uid://ddchieu337gsy"]
 
 [ext_resource type="PackedScene" uid="uid://6mhb0a0g3kj8" path="res://scenes/board/Board.tscn" id="1_idj7w"]
 [ext_resource type="Script" uid="uid://mpe2jq6utcpi" path="res://scenes/main.gd" id="1_kln2b"]
 [ext_resource type="PackedScene" uid="uid://cheurswfn12g" path="res://scenes/hand/Hand.tscn" id="2_kln2b"]
 [ext_resource type="PackedScene" uid="uid://b7137nxmc3c7y" path="res://scenes/debug/DebugConsole.tscn" id="5_pbw6q"]
+[ext_resource type="PackedScene" uid="uid://cscoel3dj5cps" path="res://scenes/ui/MultiSelectIndicator.tscn" id="6_multi"]
 
 [node name="Main" type="Control"]
 layout_mode = 3
@@ -22,3 +23,6 @@ layout_mode = 1
 
 [node name="DebugConsole" parent="." instance=ExtResource("5_pbw6q")]
 visible = false
+
+[node name="MultiSelectIndicator" parent="." instance=ExtResource("6_multi")]
+layout_mode = 1

--- a/scenes/hand/hand.gd
+++ b/scenes/hand/hand.gd
@@ -8,7 +8,6 @@ class_name Hand
 # === Signals ===
 signal tile_added(tile: Tile)
 signal tile_removed(tile: Tile)
-signal selection_changed(selected_tiles: Array[Tile])
 signal hand_empty()
 
 # === Configuration ===
@@ -16,9 +15,6 @@ signal hand_empty()
 
 # === Node References ===
 @onready var tile_container: HBoxContainer = $TileContainer
-
-# === State ===
-var _selected_tiles: Array[Tile] = []
 
 
 func _ready() -> void:
@@ -44,10 +40,8 @@ func remove_tile(tile: Tile) -> bool:
 	if not _has_tile(tile):
 		return false
 
-	# Deselect if selected
-	if tile in _selected_tiles:
-		_selected_tiles.erase(tile)
-		selection_changed.emit(_selected_tiles)
+	# Deselect if selected (via SelectionManager)
+	SelectionManager.deselect_tile(tile)
 
 	tile_container.remove_child(tile)
 	tile_removed.emit(tile)
@@ -61,76 +55,58 @@ func remove_tile(tile: Tile) -> bool:
 ## Removes and returns all tiles from the hand.
 func clear_hand() -> Array[Tile]:
 	var tiles: Array[Tile] = get_tiles()
+
+	# Deselect tiles that are in hand
 	for tile in tiles:
+		SelectionManager.deselect_tile(tile)
 		tile_container.remove_child(tile)
 
-	_selected_tiles.clear()
-	selection_changed.emit(_selected_tiles)
 	hand_empty.emit()
 
 	return tiles
 
 
-# === Public API: Selection ===
+# === Public API: Selection (delegates to SelectionManager) ===
 
-## Selects a single tile, deselecting others.
+## Selects a tile (mode-aware via SelectionManager).
 func select_tile(tile: Tile) -> void:
 	if not _has_tile(tile):
 		return
-
-	# Deselect all others
-	for t in _selected_tiles:
-		t.set_selected(false)
-
-	_selected_tiles.clear()
-	_selected_tiles.append(tile)
-	tile.set_selected(true)
-
-	selection_changed.emit(_selected_tiles)
+	SelectionManager.select_tile(tile)
 
 
 ## Toggles selection state of a tile (for multi-select).
 func toggle_tile_selection(tile: Tile) -> void:
 	if not _has_tile(tile):
 		return
-
-	if tile in _selected_tiles:
-		_selected_tiles.erase(tile)
-		tile.set_selected(false)
-	else:
-		_selected_tiles.append(tile)
-		tile.set_selected(true)
-
-	selection_changed.emit(_selected_tiles)
+	# In multi-select mode, SelectionManager.select_tile toggles
+	SelectionManager.select_tile(tile)
 
 
 ## Deselects all tiles.
 func deselect_all() -> void:
-	for tile in _selected_tiles:
-		tile.set_selected(false)
-
-	_selected_tiles.clear()
-	selection_changed.emit(_selected_tiles)
+	SelectionManager.deselect_all()
 
 
 ## Selects all tiles in the hand.
 func select_all() -> void:
-	_selected_tiles.clear()
 	for tile in get_tiles():
-		tile.set_selected(true)
-		_selected_tiles.append(tile)
-
-	selection_changed.emit(_selected_tiles)
+		SelectionManager.select_tile(tile)
 
 
-## Returns currently selected tiles.
+## Returns currently selected tiles that are in this hand.
 func get_selected_tiles() -> Array[Tile]:
-	return _selected_tiles.duplicate()
+	var all_selected: Array[Tile] = SelectionManager.get_selected_tiles()
+	var in_hand: Array[Tile] = []
+	for tile in all_selected:
+		if _has_tile(tile):
+			in_hand.append(tile)
+	return in_hand
 
 
-## Returns true if any tiles are selected.
+## Returns true if any tiles in hand are selected.
 func has_selection() -> bool:
-	return not _selected_tiles.is_empty()
+	return not get_selected_tiles().is_empty()
 
 
 # === Public API: Queries ===

--- a/scenes/main.gd
+++ b/scenes/main.gd
@@ -19,14 +19,24 @@ enum InteractionMode {
 var selected_tile: Tile = null
 var interaction_mode: InteractionMode = InteractionMode.IDLE
 
+# === Multi-Drag State ===
+var _dragged_tiles: Array[Tile] = []
+var _drag_original_positions: Dictionary = {}  # Tile -> {parent: Node, index: int}
+var _last_placement_success: bool = false
+
 # === Node References ===
 @onready var board: Board = $Board
-@onready var hand: Control = $Hand
+@onready var hand: Hand = $Hand
 
 
 func _ready() -> void:
 	_connect_board_signals()
 	_start_game()
+
+
+func _unhandled_input(event: InputEvent) -> void:
+	if event.is_action_pressed("toggle_multi_select"):
+		SelectionManager.toggle_mode()
 
 
 func _process(_delta: float) -> void:
@@ -56,34 +66,25 @@ func _start_game() -> void:
 func _on_tile_selected(tile: Tile) -> void:
 	print("[Main] Tile selected: %s" % tile.name)
 
-	# Clicking a board tile while holding another tile
-	if interaction_mode == InteractionMode.TILE_SELECTED and tile.location == Tile.TileLocation.ON_BOARD:
+	# Clicking a board tile while we have selection
+	if SelectionManager.has_selection() and tile.location == Tile.TileLocation.ON_BOARD:
 		print("[Main] Cannot stack tiles")
 		return
 
 	# Clicking a tile that's already on the board (info only)
-	if interaction_mode == InteractionMode.IDLE and tile.location == Tile.TileLocation.ON_BOARD:
+	if not SelectionManager.has_selection() and tile.location == Tile.TileLocation.ON_BOARD:
 		print("[Main] Board tile at cell: %s" % tile.current_cell.name)
 		return
 
-	# Toggle selection if clicking the same tile
-	if interaction_mode == InteractionMode.TILE_SELECTED:
-		if selected_tile == tile:
-			_deselect_tile()
-			return
-		# Deselect current tile before selecting new one
-		selected_tile.set_selected(false)
-
-	# Select the new tile
-	selected_tile = tile
-	selected_tile.set_selected(true)
-	interaction_mode = InteractionMode.TILE_SELECTED
-	_set_hand_tiles_hover_enabled(false)
+	# Hand tile - use SelectionManager
+	if tile.location == Tile.TileLocation.IN_HAND:
+		SelectionManager.select_tile(tile)
+		_update_interaction_state()
 
 
 func _on_tile_right_clicked(tile: Tile) -> void:
-	if selected_tile != null:
-		print("[Main] Cannot remove tile while another is selected")
+	if SelectionManager.has_selection():
+		print("[Main] Cannot remove tile while selection active")
 		return
 
 	if tile.current_cell == null:
@@ -93,42 +94,55 @@ func _on_tile_right_clicked(tile: Tile) -> void:
 	return_tile_to_hand(tile)
 
 
+func _on_tile_drag_started(tile: Tile) -> void:
+	# Get all selected tiles for multi-drag
+	_dragged_tiles = SelectionManager.get_selected_tiles()
+
+	# If dragged tile is not in selection, select only it
+	if tile not in _dragged_tiles:
+		SelectionManager.deselect_all()
+		SelectionManager.select_tile(tile)
+		_dragged_tiles = [tile]
+
+	# Store original positions for potential cancellation
+	_store_original_positions()
+
+	if _dragged_tiles.size() > 1:
+		EventBus.multi_drag_started.emit(_dragged_tiles)
+		print("[Main] Multi-drag started with %d tiles" % _dragged_tiles.size())
+
+
 func _on_tile_drag_ended(tile: Tile) -> void:
 	var cell: BoardCell = _get_cell_under_mouse()
 
 	var cell_name: String = String(cell.name) if cell else "none"
-	print("[Main] Drag ended - Tile: %s | Location: %s | Cell: %s" % [
+	print("[Main] Drag ended - Tile: %s | Location: %s | Cell: %s | Multi: %d" % [
 		tile.name,
 		Tile.TileLocation.keys()[tile.location],
-		cell_name
+		cell_name,
+		_dragged_tiles.size()
 	])
 
-	# Dropped outside board
-	if cell == null:
-		if tile.location == Tile.TileLocation.ON_BOARD:
-			_return_to_original_cell(tile)
-		else:
-			_cancel_drag_to_hand(tile)
-		return
+	# Handle multi-tile or single-tile drop
+	if _dragged_tiles.size() > 1:
+		_handle_multi_tile_drop(cell)
+	else:
+		_handle_single_tile_drop(tile, cell)
 
-	# Dropped on occupied cell
-	if cell.is_occupied():
-		print("[Main] Cannot drop on occupied cell: %s" % cell.name)
-		if tile.location == Tile.TileLocation.ON_BOARD:
-			_return_to_original_cell(tile)
-		else:
-			_cancel_drag_to_hand(tile)
-		return
+	# Emit drag ended event
+	if _dragged_tiles.size() > 1:
+		EventBus.multi_drag_ended.emit(_dragged_tiles, _last_placement_success)
 
-	# Valid placement
-	print("[Main] Valid drop on cell: %s" % cell.name)
-	place_tile_on_cell(tile, cell)
+	_dragged_tiles.clear()
+	_drag_original_positions.clear()
 
 
 # === Cell Handlers ===
 
 func _on_cell_clicked(cell: BoardCell) -> void:
-	if selected_tile == null:
+	var selected_tiles: Array[Tile] = SelectionManager.get_selected_tiles()
+
+	if selected_tiles.is_empty():
 		print("[Main] No tile selected")
 		return
 
@@ -136,17 +150,46 @@ func _on_cell_clicked(cell: BoardCell) -> void:
 		print("[Main] Cell occupied: %s" % cell.name)
 		return
 
-	place_tile_on_cell(selected_tile, cell)
+	# Multi-tile click placement
+	if selected_tiles.size() > 1:
+		var cells: Array[BoardCell] = _get_sequential_cells(cell, selected_tiles.size())
+		if cells.is_empty():
+			print("[Main] Cannot place %d tiles starting at %s" % [selected_tiles.size(), cell.name])
+			return
+
+		# Place all tiles
+		for i in selected_tiles.size():
+			_place_tile_on_cell_silent(selected_tiles[i], cells[i])
+
+		SelectionManager.deselect_all()
+		_update_interaction_state()
+		print("[Main] Placed %d tiles starting at %s" % [selected_tiles.size(), cell.name])
+	else:
+		# Single tile placement
+		place_tile_on_cell(selected_tiles[0], cell)
 
 
 func _on_cell_hovered(cell: BoardCell) -> void:
-	if interaction_mode != InteractionMode.TILE_SELECTED:
+	if not SelectionManager.has_selection():
 		return
 
-	if cell.is_occupied():
-		cell.show_invalid_hover()
+	var selected_count: int = SelectionManager.get_selection_count()
+
+	if selected_count > 1:
+		# Multi-tile hover - check if all sequential cells are valid
+		var cells: Array[BoardCell] = _get_sequential_cells(cell, selected_count)
+		if cells.is_empty():
+			cell.show_invalid_hover()
+		else:
+			# Show valid hover on all cells that would be used
+			for c in cells:
+				c.show_valid_hover()
 	else:
-		cell.show_valid_hover()
+		# Single tile hover
+		if cell.is_occupied():
+			cell.show_invalid_hover()
+		else:
+			cell.show_valid_hover()
 
 
 func _on_cell_unhovered(cell: BoardCell) -> void:
@@ -156,6 +199,19 @@ func _on_cell_unhovered(cell: BoardCell) -> void:
 # === Tile Placement ===
 
 func place_tile_on_cell(tile: Tile, cell: BoardCell) -> void:
+	if cell.is_occupied():
+		return
+
+	_place_tile_on_cell_silent(tile, cell)
+
+	# Deselect and reset interaction
+	SelectionManager.deselect_tile(tile)
+	_update_interaction_state()
+
+
+## Places a tile on a cell without deselecting or updating interaction state.
+## Used for multi-tile placement where we batch the state updates.
+func _place_tile_on_cell_silent(tile: Tile, cell: BoardCell) -> void:
 	if cell.is_occupied():
 		return
 
@@ -177,12 +233,6 @@ func place_tile_on_cell(tile: Tile, cell: BoardCell) -> void:
 	# Update cell state
 	cell.tile = tile
 
-	# Reset interaction state
-	tile.set_selected(false)
-	selected_tile = null
-	interaction_mode = InteractionMode.IDLE
-
-	_set_hand_tiles_hover_enabled(true)
 	_clear_all_cell_hovers()
 
 	EventBus.tile_placed.emit(tile, cell)
@@ -191,6 +241,21 @@ func place_tile_on_cell(tile: Tile, cell: BoardCell) -> void:
 
 
 func return_tile_to_hand(tile: Tile) -> void:
+	_return_tile_to_hand_internal(tile, false)
+
+
+func _return_tile_to_hand_internal(tile: Tile, preserve_selection: bool) -> void:
+	if tile.current_cell == null and tile.location != Tile.TileLocation.IN_HAND:
+		# Tile being returned from drag, not from board
+		if tile.get_parent():
+			tile.get_parent().remove_child(tile)
+		hand.add_tile(tile)
+		tile.location = Tile.TileLocation.IN_HAND
+		tile.modulate = Color.WHITE
+		if not preserve_selection:
+			SelectionManager.deselect_tile(tile)
+		return
+
 	if tile.current_cell == null:
 		return
 
@@ -206,9 +271,11 @@ func return_tile_to_hand(tile: Tile) -> void:
 	# Update tile state
 	tile.current_cell = null
 	tile.location = Tile.TileLocation.IN_HAND
-	tile.set_selected(false)
 
-	interaction_mode = InteractionMode.IDLE
+	if not preserve_selection:
+		SelectionManager.deselect_tile(tile)
+
+	_update_interaction_state()
 	_clear_all_cell_hovers()
 
 	EventBus.tile_removed.emit(tile, cell)
@@ -218,14 +285,23 @@ func return_tile_to_hand(tile: Tile) -> void:
 
 # === Private Helpers ===
 
-func _deselect_tile() -> void:
-	if selected_tile != null:
-		selected_tile.set_selected(false)
-		selected_tile = null
+func _update_interaction_state() -> void:
+	var has_selection: bool = SelectionManager.has_selection()
 
-	interaction_mode = InteractionMode.IDLE
-	_clear_all_cell_hovers()
-	_set_hand_tiles_hover_enabled(true)
+	if has_selection:
+		interaction_mode = InteractionMode.TILE_SELECTED
+		selected_tile = SelectionManager.get_selected_tiles()[0] if SelectionManager.get_selection_count() == 1 else null
+		_set_hand_tiles_hover_enabled(false)
+	else:
+		interaction_mode = InteractionMode.IDLE
+		selected_tile = null
+		_set_hand_tiles_hover_enabled(true)
+		_clear_all_cell_hovers()
+
+
+func _deselect_tile() -> void:
+	SelectionManager.deselect_all()
+	_update_interaction_state()
 
 
 func _set_hand_tiles_hover_enabled(enabled: bool) -> void:
@@ -243,8 +319,110 @@ func _clear_all_cell_hovers() -> void:
 		cell.clear_hover()
 
 
+func _store_original_positions() -> void:
+	_drag_original_positions.clear()
+	for tile in _dragged_tiles:
+		var parent: Node = tile.get_parent()
+		var index: int = parent.get_children().find(tile) if parent else -1
+		_drag_original_positions[tile] = {"parent": parent, "index": index}
+
+
+func _handle_single_tile_drop(tile: Tile, cell: BoardCell) -> void:
+	# Dropped outside board
+	if cell == null:
+		if tile.location == Tile.TileLocation.ON_BOARD:
+			_return_to_original_cell(tile)
+		else:
+			_cancel_drag_to_hand(tile)
+		_last_placement_success = false
+		return
+
+	# Dropped on occupied cell
+	if cell.is_occupied():
+		print("[Main] Cannot drop on occupied cell: %s" % cell.name)
+		if tile.location == Tile.TileLocation.ON_BOARD:
+			_return_to_original_cell(tile)
+		else:
+			_cancel_drag_to_hand(tile)
+		_last_placement_success = false
+		return
+
+	# Valid placement
+	print("[Main] Valid drop on cell: %s" % cell.name)
+	place_tile_on_cell(tile, cell)
+	_last_placement_success = true
+
+
+func _handle_multi_tile_drop(start_cell: BoardCell) -> void:
+	if start_cell == null:
+		_cancel_multi_drag_preserve_selection()
+		_last_placement_success = false
+		return
+
+	# Validate all tiles can be placed in sequence
+	var cells: Array[BoardCell] = _get_sequential_cells(start_cell, _dragged_tiles.size())
+	if cells.is_empty():
+		print("[Main] Cannot place %d tiles starting at %s" % [_dragged_tiles.size(), start_cell.name])
+		_cancel_multi_drag_preserve_selection()
+		_last_placement_success = false
+		return
+
+	# Place all tiles
+	for i in _dragged_tiles.size():
+		_place_tile_on_cell_silent(_dragged_tiles[i], cells[i])
+
+	# Deselect all after successful placement
+	SelectionManager.deselect_all()
+	_update_interaction_state()
+	_last_placement_success = true
+	print("[Main] Multi-drop: placed %d tiles starting at %s" % [_dragged_tiles.size(), start_cell.name])
+
+
+func _get_sequential_cells(start: BoardCell, count: int) -> Array[BoardCell]:
+	var cells: Array[BoardCell] = []
+	var pos: Vector2i = start.grid_position
+	var direction: Vector2i = Vector2i.RIGHT  # Future: configurable direction
+
+	for i in count:
+		var cell: BoardCell = board.get_cell(pos.y, pos.x)
+		if cell == null or cell.is_occupied():
+			return []  # Invalid - return empty
+		cells.append(cell)
+		pos += direction
+	return cells
+
+
+func _cancel_multi_drag_preserve_selection() -> void:
+	for tile in _dragged_tiles:
+		_return_tile_to_original_position(tile)
+	# Selection is preserved - tiles remain selected
+	_update_interaction_state()
+	print("[Main] Multi-drag cancelled, selection preserved")
+
+
+func _return_tile_to_original_position(tile: Tile) -> void:
+	if not _drag_original_positions.has(tile):
+		_cancel_drag_to_hand(tile)
+		return
+
+	var original: Dictionary = _drag_original_positions[tile]
+	var parent: Node = original.get("parent")
+
+	if tile.location == Tile.TileLocation.ON_BOARD:
+		# Was on board - return to cell
+		_return_to_original_cell(tile)
+	else:
+		# Was in hand - return to hand preserving selection
+		if tile.get_parent():
+			tile.get_parent().remove_child(tile)
+		hand.add_tile(tile)
+		tile.location = Tile.TileLocation.IN_HAND
+		tile.current_cell = null
+		tile.modulate = Color.WHITE
+		# Don't deselect - preserve selection
+
+
 func _cancel_drag_to_hand(tile: Tile) -> void:
-	"""Returns tile to hand after cancelled drag (tile was never on board)."""
 	if tile.get_parent():
 		tile.get_parent().remove_child(tile)
 
@@ -253,16 +431,18 @@ func _cancel_drag_to_hand(tile: Tile) -> void:
 	tile.location = Tile.TileLocation.IN_HAND
 	tile.current_cell = null
 	tile.modulate = Color.WHITE
-	tile.set_selected(false)
 
-	interaction_mode = InteractionMode.IDLE
+	# Deselect only in single mode or if this is not a multi-drag
+	if not SelectionManager.is_multi_select_enabled() or _dragged_tiles.size() <= 1:
+		SelectionManager.deselect_tile(tile)
+
+	_update_interaction_state()
 	_clear_all_cell_hovers()
 
 	print("[Main] Cancelled drag for tile: %s" % tile.name)
 
 
 func _return_to_original_cell(tile: Tile) -> void:
-	"""Returns dragged board tile back to its current cell."""
 	if tile.current_cell == null:
 		push_error("[Main] Board tile has no current_cell reference!")
 		return

--- a/scenes/tile/tile.gd
+++ b/scenes/tile/tile.gd
@@ -14,6 +14,9 @@ signal tile_drag_ended(tile: Tile)
 # === Constants ===
 const DRAG_THRESHOLD: float = 8.0  # Pixels before drag starts
 const DRAG_Z_INDEX: int = 100      # Z-index while dragging
+const SELECTED_SCALE: Vector2 = Vector2(1.05, 1.05)
+const NORMAL_SCALE: Vector2 = Vector2(1.0, 1.0)
+const SCALE_TWEEN_DURATION: float = 0.1
 
 # === Enums ===
 
@@ -49,6 +52,7 @@ var current_cell: BoardCell = null  # Only valid when ON_BOARD
 # === Selection State ===
 var is_selected: bool = false
 var allow_hover_feedback: bool = true
+var selection_order: int = -1  # -1 = not selected
 
 # === Drag State ===
 var _drag_state: DragState = DragState.IDLE
@@ -120,6 +124,19 @@ func initialize(data: LetterTileData) -> void:
 func set_selected(value: bool) -> void:
 	is_selected = value
 	_update_visual()
+	_animate_selection_scale()
+
+
+## Set the selection order for multi-select.
+func set_selection_order(order: int) -> void:
+	selection_order = order
+
+
+func _animate_selection_scale() -> void:
+	var target_scale: Vector2 = SELECTED_SCALE if is_selected else NORMAL_SCALE
+	var tween: Tween = create_tween()
+	tween.tween_property(self, "scale", target_scale, SCALE_TWEEN_DURATION) \
+		.set_ease(Tween.EASE_OUT)
 
 
 ## Get the total point value including modifiers.
@@ -139,6 +156,8 @@ func reset() -> void:
 	point_modifier = 0
 	current_cell = null
 	location = TileLocation.IN_BAG
+	selection_order = -1
+	scale = NORMAL_SCALE
 	_drag_state = DragState.IDLE
 	_update_visual()
 

--- a/scenes/ui/MultiSelectIndicator.tscn
+++ b/scenes/ui/MultiSelectIndicator.tscn
@@ -1,0 +1,30 @@
+[gd_scene load_steps=2 format=3 uid="uid://cscoel3dj5cps"]
+
+[ext_resource type="Script" path="res://scenes/ui/multi_select_indicator.gd" id="1_indicator"]
+
+[node name="MultiSelectIndicator" type="Control"]
+anchors_preset = 0
+offset_left = 20.0
+offset_top = 20.0
+offset_right = 120.0
+offset_bottom = 50.0
+script = ExtResource("1_indicator")
+
+[node name="Background" type="Panel" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="ModeLabel" type="Label" parent="Background"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+text = "[Q] Multi"
+horizontal_alignment = 1
+vertical_alignment = 1

--- a/scenes/ui/multi_select_indicator.gd
+++ b/scenes/ui/multi_select_indicator.gd
@@ -1,0 +1,40 @@
+extends Control
+
+## MultiSelectIndicator: Visual indicator for multi-select mode status.
+## Shows current mode and selection count.
+
+@onready var background: Panel = $Background
+@onready var mode_label: Label = $Background/ModeLabel
+
+# Colors for different states
+const COLOR_MULTI_ACTIVE: Color = Color(0.2, 0.6, 0.3, 0.9)
+const COLOR_SINGLE: Color = Color(0.3, 0.3, 0.3, 0.5)
+
+
+func _ready() -> void:
+	EventBus.selection_mode_changed.connect(_on_mode_changed)
+	EventBus.selection_changed.connect(_on_selection_changed)
+	_update_display()
+
+
+func _on_mode_changed(_is_multi: bool) -> void:
+	_update_display()
+
+
+func _on_selection_changed(_tiles: Array) -> void:
+	_update_display()
+
+
+func _update_display() -> void:
+	var is_multi: bool = SelectionManager.is_multi_select_enabled()
+	var count: int = SelectionManager.get_selection_count()
+
+	if is_multi:
+		background.modulate = COLOR_MULTI_ACTIVE
+		if count == 0:
+			mode_label.text = "MULTI [Q]"
+		else:
+			mode_label.text = "MULTI [%d]" % count
+	else:
+		background.modulate = COLOR_SINGLE
+		mode_label.text = "[Q] Multi"

--- a/scenes/ui/multi_select_indicator.gd.uid
+++ b/scenes/ui/multi_select_indicator.gd.uid
@@ -1,0 +1,1 @@
+uid://cj8y4servoai6


### PR DESCRIPTION
This pull request introduces a new centralized `SelectionManager` system for managing tile selection state and mode (single vs. multi-select), and refactors all selection logic across the codebase to use this new manager. It also adds support for multi-tile selection, multi-tile drag-and-drop, and sequential placement, along with new UI and input mappings to toggle multi-select mode. The changes improve code maintainability, enable more advanced interactions, and simplify selection state management.

**Selection system overhaul:**

* Added new `autoload/selection_manager.gd` as the single source of truth for tile selection, supporting both single and multi-select modes, ordered selection, and emitting relevant events (`selection_mode_changed`, `selection_changed`). [[1]](diffhunk://#diff-6d638eeb0b7c75f55c33a8c84df751b5b41106bca98b93555cd51ab18c16b9dcR1-R165) [[2]](diffhunk://#diff-90c210abfff27392d22d1f466099a609de867686355afd6039771451030b96ceR1) [[3]](diffhunk://#diff-9ddfddc202bcd66b90ba898672236811349d70732940c65b1c0edf1c0cbb0aa0R130-R145)
* All selection logic in `Hand` and `Main` is now delegated to `SelectionManager`, removing duplicate state and signals. This affects tile selection, deselection, and queries for selected tiles. [[1]](diffhunk://#diff-cfb5f3c37fe7224f3ddd5ea9299acbe4c045a3828d40640dedde6ee08e467f49L11) [[2]](diffhunk://#diff-cfb5f3c37fe7224f3ddd5ea9299acbe4c045a3828d40640dedde6ee08e467f49L20-L22) [[3]](diffhunk://#diff-cfb5f3c37fe7224f3ddd5ea9299acbe4c045a3828d40640dedde6ee08e467f49L47-R44) [[4]](diffhunk://#diff-cfb5f3c37fe7224f3ddd5ea9299acbe4c045a3828d40640dedde6ee08e467f49R58-R109) [[5]](diffhunk://#diff-681ad492c20d64ef9999a24554cf92524c1ce008d0c655a520c473873f9ca616L59-R87)

**Multi-select and multi-drag support:**

* Implemented input mapping (`toggle_multi_select`) and UI indicator for toggling multi-select mode, including integration in the main scene and project settings. [[1]](diffhunk://#diff-88c173602c6c7ccaaba6f408d21c235bda4d6884e30e71e73e1b07b9f93ad7b6R25-R38) [[2]](diffhunk://#diff-e5d2a08b5f690439565a85f97b99faef69e81729f3f7675c7730904027913a65L1-R7) [[3]](diffhunk://#diff-e5d2a08b5f690439565a85f97b99faef69e81729f3f7675c7730904027913a65R26-R28)
* Added support for multi-tile drag-and-drop, including starting and ending multi-drags, and sequential placement of multiple tiles on the board. [[1]](diffhunk://#diff-681ad492c20d64ef9999a24554cf92524c1ce008d0c655a520c473873f9ca616R22-R41) [[2]](diffhunk://#diff-681ad492c20d64ef9999a24554cf92524c1ce008d0c655a520c473873f9ca616R97-R188) [[3]](diffhunk://#diff-681ad492c20d64ef9999a24554cf92524c1ce008d0c655a520c473873f9ca616R205-R217) [[4]](diffhunk://#diff-681ad492c20d64ef9999a24554cf92524c1ce008d0c655a520c473873f9ca616L180-L185) [[5]](diffhunk://#diff-681ad492c20d64ef9999a24554cf92524c1ce008d0c655a520c473873f9ca616R244-R258) [[6]](diffhunk://#diff-681ad492c20d64ef9999a24554cf92524c1ce008d0c655a520c473873f9ca616L209-R278)
* Extended `event_bus.gd` with new signals for selection and multi-drag events.

**Signal and connection updates:**

* Updated signal connections in `hand_manager.gd` to include drag events for tiles.

These changes collectively provide a robust and extensible selection system, paving the way for advanced user interactions and cleaner code organization.