### PR TITLE
Drag and Drop Improvements

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -5,7 +5,8 @@
       "Bash(grep:*)",
       "Bash(for file in C:/Users/suporte/Documents/dev/Data/TileData/tiles/tile_[b-z].tres)",
       "Bash(do sed -i 's/letter = \"\" \\\\\\([A-Z]\\\\\\)\"\"/letter = \"\"\\\\1\"\"/' \"$file\")",
-      "Bash(done)"
+      "Bash(done)",
+      "Bash(godot:*)"
     ]
   }
 }

--- a/autoload/AGENT.md
+++ b/autoload/AGENT.md
@@ -10,6 +10,7 @@ Global singleton managers that coordinate game-wide systems. These are automatic
 - `tile_bag.gd` - Tile pool (deck) management
 - `selection_manager.gd` - Tile selection state (single/multi-select)
 - `tile_animator.gd` - Tile animation coordinator
+- `drag_manager.gd` - Multi-tile drag coordination
 - `debug_manager.gd` - Debug commands and logging
 
 ---
@@ -399,6 +400,73 @@ See [scripts/animation/AGENT.md](../scripts/animation/AGENT.md) for creating cus
 
 ---
 
+## DragManager
+
+### Purpose
+Coordinates multi-tile drag operations. When multiple tiles are selected and dragged, all selected tiles move together as a preview.
+
+### Key Properties
+```gdscript
+var is_dragging: bool = false
+var dragged_tiles: Array[Tile] = []
+var lead_tile: Tile = null  # The tile directly dragged by user
+```
+
+### Signals
+| Signal | Parameters | Description |
+|--------|------------|-------------|
+| `drag_started` | `tiles: Array[Tile]` | Multi-drag began |
+| `drag_updated` | `tiles, position` | Drag position changed |
+| `drag_ended` | `tiles, success` | Drag finished |
+| `drag_cancelled` | `tiles: Array[Tile]` | Drag was cancelled |
+
+### Key Methods
+```gdscript
+# Drag lifecycle
+start_drag(lead: Tile, tiles: Array[Tile]) -> void   # Start drag operation
+end_drag(success: bool) -> void                       # End drag operation
+cancel_drag() -> void                                 # Cancel and restore
+
+# Tile restoration
+restore_tiles_to_parents() -> void   # Return tiles to original parents
+
+# Queries
+get_drag_position() -> Vector2       # Lead tile's position
+get_dragged_tiles() -> Array[Tile]   # Currently dragged tiles
+get_original_parent(tile) -> Node    # Tile's original parent
+get_original_position(tile) -> Vector2
+```
+
+### Drag Flow
+```
+1. User starts dragging a selected tile
+2. Main._on_tile_drag_started() gets all selected tiles
+3. DragManager.start_drag(lead, tiles) called
+   - Stores original parents, positions, indices
+   - Reparents all tiles to DragContainer
+   - Calculates relative offsets from lead
+4. During drag: DragManager._process() updates follower positions
+5. On drop: Main._on_tile_drag_ended()
+   - DragManager.restore_tiles_to_parents() returns tiles
+   - Place tiles on board OR cancel
+   - DragManager.end_drag(success) cleans up
+```
+
+### Usage
+```gdscript
+# In Main._on_tile_drag_started:
+var tiles_to_drag = SelectionManager.get_selected_tiles()
+DragManager.start_drag(tile, tiles_to_drag)
+
+# In Main._on_tile_drag_ended:
+var tiles = DragManager.get_dragged_tiles()
+DragManager.restore_tiles_to_parents()
+# ... place tiles or cancel
+DragManager.end_drag(success)
+```
+
+---
+
 ## Load Order
 Autoloads are loaded in the order specified in `project.godot`:
 1. EventBus
@@ -408,6 +476,7 @@ Autoloads are loaded in the order specified in `project.godot`:
 5. HandManager
 6. SelectionManager
 7. TileAnimator
+8. DragManager
 
 **Note**: Autoloads load before scenes, so they cannot reference scene types directly at declaration time. Use runtime type checking instead.
 

--- a/autoload/AGENT.md
+++ b/autoload/AGENT.md
@@ -339,7 +339,19 @@ Debug commands and logging utilities for development.
 ## TileAnimator
 
 ### Purpose
-Coordinates tile animations across the game. Uses the Strategy pattern for flexible animation types.
+Coordinates tile animations across the game. Uses Strategy pattern with Executor composition for flexibility.
+
+### Architecture
+TileAnimator acts as a **thin facade** that delegates to specialized executors:
+
+```
+TileAnimator (facade)
+├── AnimationContext (shared state)
+├── BatchAnimationExecutor (draw animations)
+├── ReturnAnimationExecutor (return/cancel animations)
+├── ShakeAnimationExecutor (shake effect)
+└── StompAnimationExecutor (stomp with particles)
+```
 
 ### Signals
 | Signal | Parameters | Description |
@@ -353,6 +365,7 @@ Coordinates tile animations across the game. Uses the Strategy pattern for flexi
 # Main API
 animate_draw_batch(tiles: Array[Tile]) -> void          # Draw animation
 animate_return_to_hand(tile, hand, cell) -> void        # Return from board
+animate_cancel_to_hand(tiles, hand) -> void             # Cancel drag animation
 animate_shake(tile: Tile) -> void                       # Illegal action feedback
 animate_stomp_batch(tiles: Array[Tile]) -> void         # Play confirmation
 
@@ -394,7 +407,16 @@ TileAnimator uses animation strategies from `scripts/animation/`:
 - **DrawTileAnimation** - Tiles rise from below, scale up, fade in
 - **ReturnToHandAnimation** - Tiles glide from board to hand with bounce
 - **ShakeTileAnimation** - Tiles shake left-right for illegal action feedback
-- **StompTileAnimation** - Tiles stomp (scale up/down) when played
+- **StompTileAnimation** - Tiles stomp (scale up/down) with impact particles
+
+### Executor Classes
+Located in `scripts/animation/executors/`:
+- **AnimationContext** - Shared state (active tweens, signals)
+- **AnimationExecutor** - Base class with common helpers
+- **BatchAnimationExecutor** - Staggered batch animations
+- **ReturnAnimationExecutor** - Return-to-hand and cancel animations
+- **ShakeAnimationExecutor** - Shake effect for illegal actions
+- **StompAnimationExecutor** - Stomp effect with particle spawning
 
 See [scripts/animation/AGENT.md](../scripts/animation/AGENT.md) for creating custom animations.
 
@@ -416,14 +438,14 @@ var lead_tile: Tile = null  # The tile directly dragged by user
 | Signal | Parameters | Description |
 |--------|------------|-------------|
 | `drag_started` | `tiles: Array[Tile]` | Multi-drag began |
-| `drag_updated` | `tiles, position` | Drag position changed |
 | `drag_ended` | `tiles, success` | Drag finished |
 | `drag_cancelled` | `tiles: Array[Tile]` | Drag was cancelled |
+| `drag_release_requested` | `lead_tile: Tile` | Mouse released during drag |
 
 ### Key Methods
 ```gdscript
 # Drag lifecycle
-start_drag(lead: Tile, tiles: Array[Tile]) -> void   # Start drag operation
+start_drag(lead: Tile, tiles: Array[Tile]) -> void   # Start drag (lead must be in tiles)
 end_drag(success: bool) -> void                       # End drag operation
 cancel_drag() -> void                                 # Cancel and restore
 

--- a/autoload/drag_manager.gd
+++ b/autoload/drag_manager.gd
@@ -9,7 +9,6 @@ extends Node
 # =============================================================================
 
 signal drag_started(tiles: Array[Tile])
-signal drag_updated(tiles: Array[Tile], position: Vector2)
 signal drag_ended(tiles: Array[Tile], success: bool)
 signal drag_cancelled(tiles: Array[Tile])
 signal drag_release_requested(lead_tile: Tile)  # Mouse released during drag
@@ -63,7 +62,7 @@ func _process(_delta: float) -> void:
 
 ## Starts a multi-tile drag operation.
 ## Parameters:
-##   lead: The tile being directly dragged by the user
+##   lead: The tile being directly dragged by the user (must be in tiles array)
 ##   tiles: All tiles to drag (including lead tile)
 func start_drag(lead: Tile, tiles: Array[Tile]) -> void:
 	if is_dragging:
@@ -72,11 +71,15 @@ func start_drag(lead: Tile, tiles: Array[Tile]) -> void:
 	if tiles.is_empty():
 		return
 
+	if lead not in tiles:
+		push_error("[DragManager] Lead tile must be in tiles array")
+		return
+
 	is_dragging = true
 	lead_tile = lead
 	dragged_tiles = tiles.duplicate()
 
-	# Store original state
+	# Store original state and clear board cell references
 	_store_original_state()
 
 	# Calculate relative offsets from lead tile
@@ -225,6 +228,11 @@ func _setup_drag_container() -> void:
 	# Reparent tiles to drag container
 	for tile in dragged_tiles:
 		var global_pos: Vector2 = tile.global_position
+
+		# Clear board cell reference so the cell is available for placement
+		if tile.location == Tile.TileLocation.ON_BOARD and tile.current_cell:
+			tile.current_cell.tile = null
+
 		if tile.get_parent():
 			tile.get_parent().remove_child(tile)
 		_drag_container.add_child(tile)
@@ -277,6 +285,10 @@ func _restore_tiles_to_original() -> void:
 			# Restore original child order if index was stored
 			if original_index >= 0 and original_index < original_parent.get_child_count():
 				original_parent.move_child(tile, original_index)
+
+		# Restore board cell reference if tile was on board
+		if tile.location == Tile.TileLocation.ON_BOARD and tile.current_cell:
+			tile.current_cell.tile = tile
 
 		# Reset tile's internal drag state
 		tile.force_end_drag()

--- a/autoload/drag_manager.gd
+++ b/autoload/drag_manager.gd
@@ -1,0 +1,296 @@
+extends Node
+
+## DragManager: Coordinates multi-tile drag operations.
+## Handles visual positioning of all dragged tiles during drag.
+## Separates drag logic from individual tile behavior.
+
+# =============================================================================
+# SIGNALS
+# =============================================================================
+
+signal drag_started(tiles: Array[Tile])
+signal drag_updated(tiles: Array[Tile], position: Vector2)
+signal drag_ended(tiles: Array[Tile], success: bool)
+signal drag_cancelled(tiles: Array[Tile])
+signal drag_release_requested(lead_tile: Tile)  # Mouse released during drag
+
+# =============================================================================
+# STATE
+# =============================================================================
+
+var is_dragging: bool = false
+var dragged_tiles: Array[Tile] = []
+var lead_tile: Tile = null  # The tile being directly dragged
+
+# Original state for restoration
+var _original_parents: Dictionary = {}  # Tile -> Node
+var _original_positions: Dictionary = {}  # Tile -> Vector2
+var _original_indices: Dictionary = {}  # Tile -> int
+var _relative_offsets: Dictionary = {}  # Tile -> Vector2 (offset from lead tile)
+
+# Drag container for reparenting tiles during drag
+var _drag_container: Control = null
+
+# Configuration
+const DRAG_Z_INDEX: int = 100
+const TILE_SPACING: float = 68.0  # Spacing between tiles in drag preview
+
+
+func _ready() -> void:
+	# Create a container for dragged tiles (will be added to scene when needed)
+	_drag_container = Control.new()
+	_drag_container.name = "DragContainer"
+	_drag_container.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	_drag_container.z_index = DRAG_Z_INDEX
+
+
+func _input(event: InputEvent) -> void:
+	# Catch mouse release during drag - tiles may not receive it after reparenting
+	if is_dragging and event is InputEventMouseButton:
+		if event.button_index == MOUSE_BUTTON_LEFT and not event.pressed:
+			print("[DragManager] Mouse released during drag")
+			drag_release_requested.emit(lead_tile)
+
+
+func _process(_delta: float) -> void:
+	if is_dragging and lead_tile:
+		_update_drag_positions()
+
+
+# =============================================================================
+# PUBLIC API
+# =============================================================================
+
+## Starts a multi-tile drag operation.
+## Parameters:
+##   lead: The tile being directly dragged by the user
+##   tiles: All tiles to drag (including lead tile)
+func start_drag(lead: Tile, tiles: Array[Tile]) -> void:
+	if is_dragging:
+		cancel_drag()
+
+	if tiles.is_empty():
+		return
+
+	is_dragging = true
+	lead_tile = lead
+	dragged_tiles = tiles.duplicate()
+
+	# Store original state
+	_store_original_state()
+
+	# Calculate relative offsets from lead tile
+	_calculate_relative_offsets()
+
+	# Reparent tiles to drag container for unified movement
+	_setup_drag_container()
+
+	# Notify listeners
+	drag_started.emit(dragged_tiles)
+	EventBus.multi_drag_started.emit(dragged_tiles)
+
+	print("[DragManager] Started drag with %d tiles (lead: %s)" % [tiles.size(), lead.letter])
+
+
+## Ends the drag operation.
+## Parameters:
+##   success: Whether the drag resulted in successful placement
+func end_drag(success: bool) -> void:
+	if not is_dragging:
+		return
+
+	# Emit signals before cleanup
+	drag_ended.emit(dragged_tiles, success)
+	EventBus.multi_drag_ended.emit(dragged_tiles, success)
+
+	print("[DragManager] Ended drag (success: %s)" % success)
+
+	# Cleanup is handled by the caller (Main.gd) which will either
+	# place tiles or restore them
+	_cleanup_drag_state()
+
+
+## Cancels the drag and restores tiles to original positions.
+func cancel_drag() -> void:
+	if not is_dragging:
+		return
+
+	print("[DragManager] Cancelling drag")
+
+	# Restore tiles to original parents and positions
+	_restore_tiles_to_original()
+
+	drag_cancelled.emit(dragged_tiles)
+
+	_cleanup_drag_state()
+
+
+## Returns tiles to their original parents (for placement handling by Main).
+## Call this before placing tiles or when restoring after failed drop.
+func restore_tiles_to_parents() -> void:
+	# Sort tiles by original index (descending) to maintain order when re-adding
+	var tiles_with_indices: Array = []
+	for tile in dragged_tiles:
+		if is_instance_valid(tile):
+			var idx: int = _original_indices.get(tile, -1)
+			tiles_with_indices.append({"tile": tile, "index": idx})
+
+	# Sort by index ascending so we add them in order
+	tiles_with_indices.sort_custom(func(a, b): return a.index < b.index)
+
+	for entry in tiles_with_indices:
+		var tile: Tile = entry.tile
+		var original_index: int = entry.index
+
+		var original_parent: Node = _original_parents.get(tile)
+		if original_parent and is_instance_valid(original_parent):
+			if tile.get_parent() == _drag_container:
+				_drag_container.remove_child(tile)
+			if tile.get_parent():
+				tile.get_parent().remove_child(tile)
+			original_parent.add_child(tile)
+			tile.position = _original_positions.get(tile, Vector2.ZERO)
+
+			# Restore original child order if index was stored
+			if original_index >= 0 and original_index < original_parent.get_child_count():
+				original_parent.move_child(tile, original_index)
+
+		# Reset tile's internal drag state
+		tile.force_end_drag()
+
+
+## Gets the current drag position (lead tile's global position).
+func get_drag_position() -> Vector2:
+	if lead_tile and is_instance_valid(lead_tile):
+		return lead_tile.global_position
+	return Vector2.ZERO
+
+
+## Gets the tiles being dragged.
+func get_dragged_tiles() -> Array[Tile]:
+	return dragged_tiles
+
+
+## Gets the original parent of a tile.
+func get_original_parent(tile: Tile) -> Node:
+	return _original_parents.get(tile)
+
+
+## Gets the original position of a tile.
+func get_original_position(tile: Tile) -> Vector2:
+	return _original_positions.get(tile, Vector2.ZERO)
+
+
+# =============================================================================
+# PRIVATE: STATE MANAGEMENT
+# =============================================================================
+
+func _store_original_state() -> void:
+	_original_parents.clear()
+	_original_positions.clear()
+	_original_indices.clear()
+
+	for tile in dragged_tiles:
+		var parent: Node = tile.get_parent()
+		_original_parents[tile] = parent
+		_original_positions[tile] = tile.position
+		if parent:
+			_original_indices[tile] = tile.get_index()
+
+
+func _calculate_relative_offsets() -> void:
+	_relative_offsets.clear()
+
+	if not lead_tile:
+		return
+
+	# For horizontal arrangement, tiles are spaced out to the right of lead
+	var lead_index: int = dragged_tiles.find(lead_tile)
+
+	for i in dragged_tiles.size():
+		var tile: Tile = dragged_tiles[i]
+		# Calculate horizontal offset based on position in array relative to lead
+		var offset_index: int = i - lead_index
+		_relative_offsets[tile] = Vector2(offset_index * TILE_SPACING, 0)
+
+
+func _setup_drag_container() -> void:
+	# Add drag container to the scene if not already
+	var root: Node = get_tree().current_scene
+	if _drag_container.get_parent() != root:
+		if _drag_container.get_parent():
+			_drag_container.get_parent().remove_child(_drag_container)
+		root.add_child(_drag_container)
+
+	# Reparent tiles to drag container
+	for tile in dragged_tiles:
+		var global_pos: Vector2 = tile.global_position
+		if tile.get_parent():
+			tile.get_parent().remove_child(tile)
+		_drag_container.add_child(tile)
+		tile.global_position = global_pos
+		tile.z_index = DRAG_Z_INDEX
+		tile.modulate = Color(1.2, 1.2, 1.2)  # Highlight during drag
+
+
+func _update_drag_positions() -> void:
+	if not lead_tile or not is_instance_valid(lead_tile):
+		return
+
+	# Lead tile follows mouse (handled by Tile._process)
+	# Other tiles maintain their relative offset from lead
+	var lead_global_pos: Vector2 = lead_tile.global_position
+
+	for tile in dragged_tiles:
+		if tile == lead_tile:
+			continue
+		if not is_instance_valid(tile):
+			continue
+
+		var offset: Vector2 = _relative_offsets.get(tile, Vector2.ZERO)
+		tile.global_position = lead_global_pos + offset
+
+
+func _restore_tiles_to_original() -> void:
+	# Sort tiles by original index ascending to maintain order when re-adding
+	var tiles_with_indices: Array = []
+	for tile in dragged_tiles:
+		if is_instance_valid(tile):
+			var idx: int = _original_indices.get(tile, -1)
+			tiles_with_indices.append({"tile": tile, "index": idx})
+
+	tiles_with_indices.sort_custom(func(a, b): return a.index < b.index)
+
+	for entry in tiles_with_indices:
+		var tile: Tile = entry.tile
+		var original_index: int = entry.index
+		var original_parent: Node = _original_parents.get(tile)
+		var original_pos: Vector2 = _original_positions.get(tile, Vector2.ZERO)
+
+		if tile.get_parent() == _drag_container:
+			_drag_container.remove_child(tile)
+
+		if original_parent and is_instance_valid(original_parent):
+			original_parent.add_child(tile)
+			tile.position = original_pos
+
+			# Restore original child order if index was stored
+			if original_index >= 0 and original_index < original_parent.get_child_count():
+				original_parent.move_child(tile, original_index)
+
+		# Reset tile's internal drag state
+		tile.force_end_drag()
+
+
+func _cleanup_drag_state() -> void:
+	# Remove drag container from scene
+	if _drag_container.get_parent():
+		_drag_container.get_parent().remove_child(_drag_container)
+
+	is_dragging = false
+	lead_tile = null
+	dragged_tiles.clear()
+	_original_parents.clear()
+	_original_positions.clear()
+	_original_indices.clear()
+	_relative_offsets.clear()

--- a/autoload/drag_manager.gd
+++ b/autoload/drag_manager.gd
@@ -166,9 +166,9 @@ func get_drag_position() -> Vector2:
 	return Vector2.ZERO
 
 
-## Gets the tiles being dragged.
+## Gets the tiles being dragged (returns a copy to prevent mutation issues).
 func get_dragged_tiles() -> Array[Tile]:
-	return dragged_tiles
+	return dragged_tiles.duplicate()
 
 
 ## Gets the original parent of a tile.

--- a/autoload/drag_manager.gd.uid
+++ b/autoload/drag_manager.gd.uid
@@ -1,0 +1,1 @@
+uid://bee6kq2nvibcy

--- a/autoload/hand_manager.gd
+++ b/autoload/hand_manager.gd
@@ -225,15 +225,6 @@ func _connect_tile_signals(tile: Tile) -> void:
 	if _main_scene == null:
 		return
 
-	# Connect tile signals to main scene handlers
-	if not tile.tile_selected.is_connected(_main_scene._on_tile_selected):
-		tile.tile_selected.connect(_main_scene._on_tile_selected)
-
-	if not tile.tile_right_clicked.is_connected(_main_scene._on_tile_right_clicked):
-		tile.tile_right_clicked.connect(_main_scene._on_tile_right_clicked)
-
-	if not tile.tile_drag_started.is_connected(_main_scene._on_tile_drag_started):
-		tile.tile_drag_started.connect(_main_scene._on_tile_drag_started)
-
-	if not tile.tile_drag_ended.is_connected(_main_scene._on_tile_drag_ended):
-		tile.tile_drag_ended.connect(_main_scene._on_tile_drag_ended)
+	# Register tile with Main's gameplay controller
+	if _main_scene.has_method("register_tile"):
+		_main_scene.register_tile(tile)

--- a/autoload/tile_animator.gd
+++ b/autoload/tile_animator.gd
@@ -89,6 +89,19 @@ func animate_stomp_batch(tiles: Array[Tile]) -> void:
 	_animate_stomp_batch(tiles, _stomp_animation)
 
 
+## Animates tiles returning to hand from a cancelled drag.
+## Tiles smoothly glide from their current position to the hand.
+## Call this BEFORE restoring tiles to hand via DragManager.
+func animate_cancel_to_hand(tiles: Array[Tile], hand: Node) -> void:
+	if tiles.is_empty() or hand == null:
+		return
+
+	if _return_animation == null:
+		_return_animation = ReturnToHandAnimation.new()
+
+	_animate_cancel_batch(tiles, hand, _return_animation)
+
+
 ## Returns true if any animations are currently playing.
 func is_animating() -> bool:
 	return _is_animating
@@ -258,6 +271,84 @@ func _animate_return_single(tile: Tile, hand: Node, cell: Node, strategy: TileAn
 	)
 
 	print("[TileAnimator] Started return-to-hand animation for tile: %s" % tile.name)
+
+
+## Animates a batch of tiles returning to hand from a cancelled drag.
+func _animate_cancel_batch(tiles: Array[Tile], hand: Node, strategy: TileAnimationStrategy) -> void:
+	_is_animating = true
+	animation_started.emit(tiles)
+
+	# Step 1: Capture all tiles' current global positions
+	var start_positions: Dictionary = {}  # Tile -> Vector2
+	for tile in tiles:
+		if is_instance_valid(tile):
+			start_positions[tile] = tile.global_position
+
+	# Step 2: Restore tiles to hand via DragManager
+	DragManager.restore_tiles_to_parents()
+
+	# Step 3: Wait for layout to calculate new hand positions
+	await get_tree().process_frame
+
+	# Step 4: Animate each tile from old position to new position
+	var total_tiles: int = tiles.size()
+	var completed_count: int = 0
+
+	for i in tiles.size():
+		var tile: Tile = tiles[i]
+		if not is_instance_valid(tile):
+			completed_count += 1
+			continue
+
+		var start_global_pos: Vector2 = start_positions.get(tile, tile.global_position)
+		var final_position: Vector2 = tile.position
+		var final_global_pos: Vector2 = tile.global_position
+
+		# Calculate starting local position to match old global position
+		var global_offset: Vector2 = start_global_pos - final_global_pos
+		tile.position = final_position + global_offset
+
+		# Apply start properties
+		var start_props: Dictionary = strategy.get_start_properties()
+		_apply_properties(tile, start_props)
+		strategy.on_animation_start(tile)
+
+		# Calculate stagger delay
+		var delay: float = i * strategy.stagger_delay
+
+		# Create animation tween
+		var tween: Tween = create_tween()
+		tween.set_parallel(true)
+
+		# Position animation
+		tween.tween_property(tile, "position", final_position, strategy.duration) \
+			.set_ease(strategy.ease_type) \
+			.set_trans(strategy.trans_type) \
+			.set_delay(delay)
+
+		# Property animations
+		var end_props: Dictionary = strategy.get_end_properties()
+		for prop_name in end_props.keys():
+			tween.tween_property(tile, prop_name, end_props[prop_name], strategy.duration) \
+				.set_ease(strategy.ease_type) \
+				.set_trans(strategy.trans_type) \
+				.set_delay(delay)
+
+		_active_tweens[tile] = tween
+
+		# Track completion
+		tween.finished.connect(func():
+			strategy.on_animation_complete(tile)
+			single_tile_animated.emit(tile)
+			_active_tweens.erase(tile)
+			completed_count += 1
+
+			if completed_count >= total_tiles:
+				_is_animating = false
+				animation_completed.emit(tiles)
+		)
+
+	print("[TileAnimator] Started cancel-to-hand animation for %d tiles" % tiles.size())
 
 
 ## Animates a shake effect on a tile to indicate an illegal action.

--- a/autoload/tile_animator.gd
+++ b/autoload/tile_animator.gd
@@ -1,8 +1,8 @@
 extends Node
 
 ## TileAnimator: Coordinates tile animations across the game.
-## Uses strategy pattern for flexible animation types.
-## Handles batch animations with staggered timing.
+## Uses strategy pattern with executor composition for flexibility.
+## Acts as a thin facade delegating to specialized executors.
 
 # =============================================================================
 # SIGNALS
@@ -13,11 +13,10 @@ signal animation_completed(tiles: Array[Tile])
 signal single_tile_animated(tile: Tile)
 
 # =============================================================================
-# STATE
+# SHARED CONTEXT
 # =============================================================================
 
-var _active_tweens: Dictionary = {}  # tile -> Tween
-var _is_animating: bool = false
+var _context: AnimationContext = null
 
 # =============================================================================
 # STRATEGIES (lazy-loaded)
@@ -28,9 +27,29 @@ var _return_animation: ReturnToHandAnimation = null
 var _shake_animation: ShakeTileAnimation = null
 var _stomp_animation: StompTileAnimation = null
 
+# =============================================================================
+# EXECUTORS (lazy-loaded)
+# =============================================================================
+
+var _batch_executor: BatchAnimationExecutor = null
+var _return_executor: ReturnAnimationExecutor = null
+var _shake_executor: ShakeAnimationExecutor = null
+var _stomp_executor: StompAnimationExecutor = null
+
 
 func _ready() -> void:
-	pass
+	_setup_context()
+
+
+func _setup_context() -> void:
+	_context = AnimationContext.new()
+	_context.setup(
+		func(tiles: Array[Tile]): animation_started.emit(tiles),
+		func(tiles: Array[Tile]): animation_completed.emit(tiles),
+		func(tile: Tile): single_tile_animated.emit(tile),
+		create_tween,
+		get_tree
+	)
 
 
 # =============================================================================
@@ -43,492 +62,94 @@ func animate_draw_batch(tiles: Array[Tile]) -> void:
 	if tiles.is_empty():
 		return
 
-	if _draw_animation == null:
-		_draw_animation = DrawTileAnimation.new()
-
-	_animate_batch(tiles, _draw_animation)
+	_ensure_draw_resources()
+	_batch_executor.execute(tiles, _draw_animation)
 
 
 ## Animates a tile returning from the board to the hand.
 ## Call this BEFORE moving the tile to the hand - this method handles the move.
-## Parameters:
-##   tile: The tile to animate
-##   hand: The Hand node to add the tile to
-##   cell: The BoardCell the tile is currently on
 func animate_return_to_hand(tile: Tile, hand: Node, cell: Node) -> void:
 	if tile == null or hand == null:
 		return
 
-	if _return_animation == null:
-		_return_animation = ReturnToHandAnimation.new()
-
-	_animate_return_single(tile, hand, cell, _return_animation)
+	_ensure_return_resources()
+	_return_executor.execute_single(tile, hand, cell, _return_animation)
 
 
 ## Plays a shake animation on a tile to indicate an illegal action.
-## The tile shakes left-right quickly and returns to its original position.
 func animate_shake(tile: Tile) -> void:
 	if tile == null:
 		return
 
-	if _shake_animation == null:
-		_shake_animation = ShakeTileAnimation.new()
-
-	_animate_shake_single(tile, _shake_animation)
+	_ensure_shake_resources()
+	_shake_executor.execute(tile, _shake_animation)
 
 
 ## Animates a batch of tiles with a stomp effect to confirm placement.
-## Tiles scale up briefly then return to normal size with staggered timing.
 func animate_stomp_batch(tiles: Array[Tile]) -> void:
 	if tiles.is_empty():
 		return
 
-	if _stomp_animation == null:
-		_stomp_animation = StompTileAnimation.new()
-
-	_animate_stomp_batch(tiles, _stomp_animation)
+	_ensure_stomp_resources()
+	_stomp_executor.execute(tiles, _stomp_animation)
 
 
 ## Animates tiles returning to hand from a cancelled drag.
-## Tiles smoothly glide from their current position to the hand.
-## Call this BEFORE restoring tiles to hand via DragManager.
 func animate_cancel_to_hand(tiles: Array[Tile], hand: Node) -> void:
 	if tiles.is_empty() or hand == null:
 		return
 
-	if _return_animation == null:
-		_return_animation = ReturnToHandAnimation.new()
-
-	_animate_cancel_batch(tiles, hand, _return_animation)
+	_ensure_return_resources()
+	_return_executor.execute_cancel_batch(tiles, hand, _return_animation)
 
 
 ## Returns true if any animations are currently playing.
 func is_animating() -> bool:
-	return _is_animating
+	return _context.is_animating
 
 
 ## Cancels all active animations immediately.
 func cancel_all() -> void:
-	for tile in _active_tweens.keys():
-		var tween: Tween = _active_tweens[tile]
+	for tile in _context.active_tweens.keys():
+		var tween: Tween = _context.active_tweens[tile]
 		if is_instance_valid(tween):
 			tween.kill()
-	_active_tweens.clear()
-	_is_animating = false
+	_context.active_tweens.clear()
+	_context.is_animating = false
 
 
 ## Cancels animation for a specific tile.
 func cancel_tile_animation(tile: Tile) -> void:
-	if _active_tweens.has(tile):
-		var tween: Tween = _active_tweens[tile]
-		if is_instance_valid(tween):
-			tween.kill()
-		_active_tweens.erase(tile)
-
-		if _active_tweens.is_empty():
-			_is_animating = false
+	_context.cancel_tile_animation(tile)
 
 
 # =============================================================================
-# PRIVATE: ANIMATION EXECUTION
+# PRIVATE: LAZY INITIALIZATION
 # =============================================================================
 
-func _animate_batch(tiles: Array[Tile], strategy: TileAnimationStrategy) -> void:
-	_is_animating = true
-	animation_started.emit(tiles)
-
-	# Wait for layout to calculate final positions
-	await get_tree().process_frame
-
-	var completed_count: int = 0
-	var total_tiles: int = tiles.size()
-
-	for i in tiles.size():
-		var tile: Tile = tiles[i]
-		var delay: float = i * strategy.stagger_delay
-
-		# Capture final position after layout
-		var final_position: Vector2 = tile.position
-
-		# Set starting state
-		var start_offset: Vector2 = strategy.get_start_position_offset()
-		var start_props: Dictionary = strategy.get_start_properties()
-
-		tile.position = final_position + start_offset
-		_apply_properties(tile, start_props)
-
-		# Notify strategy of animation start
-		strategy.on_animation_start(tile)
-
-		# Create staggered animation (parallel tween with per-property delays)
-		var tween: Tween = create_tween()
-		tween.set_parallel(true)
-
-		# Position animation
-		tween.tween_property(tile, "position", final_position, strategy.duration) \
-			.set_ease(strategy.ease_type) \
-			.set_trans(strategy.trans_type) \
-			.set_delay(delay)
-
-		# Property animations (scale, modulate, etc.)
-		var end_props: Dictionary = strategy.get_end_properties()
-		for prop_name in end_props.keys():
-			tween.tween_property(tile, prop_name, end_props[prop_name], strategy.duration) \
-				.set_ease(strategy.ease_type) \
-				.set_trans(strategy.trans_type) \
-				.set_delay(delay)
-
-		_active_tweens[tile] = tween
-
-		# Track completion
-		tween.finished.connect(func():
-			strategy.on_animation_complete(tile)
-			single_tile_animated.emit(tile)
-			_active_tweens.erase(tile)
-			completed_count += 1
-
-			if completed_count >= total_tiles:
-				_is_animating = false
-				animation_completed.emit(tiles)
-		)
-
-	print("[TileAnimator] Started batch animation for %d tiles" % tiles.size())
-
-
-func _apply_properties(tile: Tile, properties: Dictionary) -> void:
-	for prop_name in properties.keys():
-		tile.set(prop_name, properties[prop_name])
-
-
-## Animates a single tile returning from board to hand.
-## Captures board position, moves to hand, then animates from old to new position.
-func _animate_return_single(tile: Tile, hand: Node, cell: Node, strategy: TileAnimationStrategy) -> void:
-	_is_animating = true
-	var tiles_array: Array[Tile] = [tile]
-	animation_started.emit(tiles_array)
-
-	# Capture the tile's current global position (on the board)
-	var start_global_pos: Vector2 = tile.global_position
-
-	# Apply start properties and notify strategy
-	var start_props: Dictionary = strategy.get_start_properties()
-	_apply_properties(tile, start_props)
-	strategy.on_animation_start(tile)
-
-	# Clear the cell's tile reference
-	if cell:
-		cell.tile = null
-
-	# Remove tile from its current parent (the cell's tile_anchor)
-	var current_parent: Node = tile.get_parent()
-	if current_parent:
-		current_parent.remove_child(tile)
-
-	# Add to hand (this triggers HBoxContainer layout)
-	hand.add_tile(tile)
-
-	# Update tile state
-	tile.current_cell = null
-	tile.location = Tile.TileLocation.IN_HAND
-
-	# Wait for layout to calculate the new hand position
-	await get_tree().process_frame
-
-	# Capture the final position in hand (local to parent)
-	var final_position: Vector2 = tile.position
-	var final_global_pos: Vector2 = tile.global_position
-
-	# Calculate where the tile should start (in local coordinates)
-	# to appear at its old board position
-	var global_offset: Vector2 = start_global_pos - final_global_pos
-	tile.position = final_position + global_offset
-
-	# Create the animation tween
-	var tween: Tween = create_tween()
-	tween.set_parallel(true)
-
-	# Position animation
-	tween.tween_property(tile, "position", final_position, strategy.duration) \
-		.set_ease(strategy.ease_type) \
-		.set_trans(strategy.trans_type)
-
-	# Property animations (scale, modulate, etc.)
-	var end_props: Dictionary = strategy.get_end_properties()
-	for prop_name in end_props.keys():
-		tween.tween_property(tile, prop_name, end_props[prop_name], strategy.duration) \
-			.set_ease(strategy.ease_type) \
-			.set_trans(strategy.trans_type)
-
-	_active_tweens[tile] = tween
-
-	# Track completion
-	tween.finished.connect(func():
-		strategy.on_animation_complete(tile)
-		single_tile_animated.emit(tile)
-		_active_tweens.erase(tile)
-		_is_animating = _active_tweens.size() > 0
-		animation_completed.emit(tiles_array)
-	)
-
-	print("[TileAnimator] Started return-to-hand animation for tile: %s" % tile.name)
-
-
-## Animates a batch of tiles returning to hand from a cancelled drag.
-func _animate_cancel_batch(tiles: Array[Tile], hand: Node, strategy: TileAnimationStrategy) -> void:
-	_is_animating = true
-	animation_started.emit(tiles)
-
-	# Step 1: Capture all tiles' current global positions
-	var start_positions: Dictionary = {}  # Tile -> Vector2
-	for tile in tiles:
-		if is_instance_valid(tile):
-			start_positions[tile] = tile.global_position
-
-	# Step 2: Restore tiles to hand via DragManager
-	DragManager.restore_tiles_to_parents()
-
-	# Step 3: Wait for layout to calculate new hand positions
-	await get_tree().process_frame
-
-	# Step 4: Animate each tile from old position to new position
-	var total_tiles: int = tiles.size()
-	var completed_count: int = 0
-
-	for i in tiles.size():
-		var tile: Tile = tiles[i]
-		if not is_instance_valid(tile):
-			completed_count += 1
-			continue
-
-		var start_global_pos: Vector2 = start_positions.get(tile, tile.global_position)
-		var final_position: Vector2 = tile.position
-		var final_global_pos: Vector2 = tile.global_position
-
-		# Calculate starting local position to match old global position
-		var global_offset: Vector2 = start_global_pos - final_global_pos
-		tile.position = final_position + global_offset
-
-		# Apply start properties
-		var start_props: Dictionary = strategy.get_start_properties()
-		_apply_properties(tile, start_props)
-		strategy.on_animation_start(tile)
-
-		# Calculate stagger delay
-		var delay: float = i * strategy.stagger_delay
-
-		# Create animation tween
-		var tween: Tween = create_tween()
-		tween.set_parallel(true)
-
-		# Position animation
-		tween.tween_property(tile, "position", final_position, strategy.duration) \
-			.set_ease(strategy.ease_type) \
-			.set_trans(strategy.trans_type) \
-			.set_delay(delay)
-
-		# Property animations
-		var end_props: Dictionary = strategy.get_end_properties()
-		for prop_name in end_props.keys():
-			tween.tween_property(tile, prop_name, end_props[prop_name], strategy.duration) \
-				.set_ease(strategy.ease_type) \
-				.set_trans(strategy.trans_type) \
-				.set_delay(delay)
-
-		_active_tweens[tile] = tween
-
-		# Track completion
-		tween.finished.connect(func():
-			strategy.on_animation_complete(tile)
-			single_tile_animated.emit(tile)
-			_active_tweens.erase(tile)
-			completed_count += 1
-
-			if completed_count >= total_tiles:
-				_is_animating = false
-				animation_completed.emit(tiles)
-		)
-
-	print("[TileAnimator] Started cancel-to-hand animation for %d tiles" % tiles.size())
-
-
-## Animates a shake effect on a tile to indicate an illegal action.
-func _animate_shake_single(tile: Tile, strategy: ShakeTileAnimation) -> void:
-	# Cancel any existing animation on this tile
-	cancel_tile_animation(tile)
-
-	_is_animating = true
-	var tiles_array: Array[Tile] = [tile]
-	animation_started.emit(tiles_array)
-
-	# Store original position
-	var original_position: Vector2 = tile.position
-
-	# Notify strategy of animation start
-	strategy.on_animation_start(tile)
-
-	# Create sequential shake animation
-	var tween: Tween = create_tween()
-
-	# Shake left-right multiple times
-	for i in strategy.shake_count:
-		# Move right
-		tween.tween_property(tile, "position:x", original_position.x + strategy.shake_distance, strategy.duration) \
-			.set_ease(strategy.ease_type) \
-			.set_trans(strategy.trans_type)
-		# Move left
-		tween.tween_property(tile, "position:x", original_position.x - strategy.shake_distance, strategy.duration) \
-			.set_ease(strategy.ease_type) \
-			.set_trans(strategy.trans_type)
-
-	# Return to original position
-	tween.tween_property(tile, "position:x", original_position.x, strategy.duration) \
-		.set_ease(strategy.ease_type) \
-		.set_trans(strategy.trans_type)
-
-	_active_tweens[tile] = tween
-
-	# Track completion
-	tween.finished.connect(func():
-		strategy.on_animation_complete(tile)
-		single_tile_animated.emit(tile)
-		_active_tweens.erase(tile)
-		_is_animating = _active_tweens.size() > 0
-		animation_completed.emit(tiles_array)
-	)
-
-	print("[TileAnimator] Started shake animation for tile: %s" % tile.name)
-
-
-## Animates a dramatic stomp effect on a batch of tiles with staggered timing.
-## Tiles rise up, slam down, squish on impact, and spawn particles.
-func _animate_stomp_batch(tiles: Array[Tile], strategy: StompTileAnimation) -> void:
-	_is_animating = true
-	animation_started.emit(tiles)
-
-	var completed_count: int = 0
-	var total_tiles: int = tiles.size()
-
-	for i in tiles.size():
-		var tile: Tile = tiles[i]
-		var delay: float = i * strategy.stagger_delay
-		var original_position: Vector2 = tile.position
-
-		# Notify strategy of animation start
-		strategy.on_animation_start(tile)
-
-		# Create sequential stomp animation
-		var tween: Tween = create_tween()
-
-		# Delay before starting
-		if delay > 0:
-			tween.tween_interval(delay)
-
-		# Phase 1: Rise up (scale up + move up)
-		tween.set_parallel(true)
-		tween.tween_property(tile, "scale", strategy.rise_scale, strategy.rise_duration) \
-			.set_ease(Tween.EASE_OUT) \
-			.set_trans(Tween.TRANS_BACK)
-		tween.tween_property(tile, "position:y", original_position.y + strategy.rise_offset, strategy.rise_duration) \
-			.set_ease(Tween.EASE_OUT) \
-			.set_trans(Tween.TRANS_QUAD)
-
-		# Phase 2: Slam down (scale down + move down fast)
-		tween.set_parallel(false)
-		tween.tween_property(tile, "scale", strategy.squish_scale, strategy.slam_duration) \
-			.set_ease(Tween.EASE_IN) \
-			.set_trans(Tween.TRANS_QUAD)
-		tween.parallel().tween_property(tile, "position:y", original_position.y, strategy.slam_duration) \
-			.set_ease(Tween.EASE_IN) \
-			.set_trans(Tween.TRANS_QUAD)
-
-		# Spawn particles on impact
-		tween.tween_callback(func(): _spawn_impact_particles(tile, strategy))
-
-		# Phase 3: Recover (bounce back to normal)
-		tween.tween_property(tile, "scale", Vector2.ONE, strategy.recover_duration) \
-			.set_ease(Tween.EASE_OUT) \
-			.set_trans(Tween.TRANS_ELASTIC)
-
-		_active_tweens[tile] = tween
-
-		# Track completion
-		tween.finished.connect(func():
-			strategy.on_animation_complete(tile)
-			single_tile_animated.emit(tile)
-			_active_tweens.erase(tile)
-			completed_count += 1
-
-			if completed_count >= total_tiles:
-				_is_animating = _active_tweens.size() > 0
-				animation_completed.emit(tiles)
-		)
-
-	print("[TileAnimator] Started stomp animation for %d tiles" % tiles.size())
-
-
-## Spawns impact particles around a tile's edges when it slams down.
-func _spawn_impact_particles(tile: Tile, strategy: StompTileAnimation) -> void:
-	var tile_size: Vector2 = tile.size if tile.size != Vector2.ZERO else Vector2(64, 64)
-
-	# Spawn particles at each edge (bottom, left, right)
-	var edge_configs: Array = [
-		# [position, direction, spread]
-		[Vector2(tile_size.x / 2, tile_size.y), Vector2(0, 1), 60.0],      # Bottom center - burst down/out
-		[Vector2(0, tile_size.y), Vector2(-1, 0.5), 45.0],                 # Bottom-left corner
-		[Vector2(tile_size.x, tile_size.y), Vector2(1, 0.5), 45.0],        # Bottom-right corner
-		[Vector2(0, tile_size.y / 2), Vector2(-1, 0), 30.0],               # Left edge
-		[Vector2(tile_size.x, tile_size.y / 2), Vector2(1, 0), 30.0],      # Right edge
-	]
-
-	var particles_per_edge: int = maxi(strategy.particle_count / edge_configs.size(), 2)
-
-	for config in edge_configs:
-		var pos: Vector2 = config[0]
-		var dir: Vector2 = config[1]
-		var spread: float = config[2]
-
-		var particles: CPUParticles2D = CPUParticles2D.new()
-
-		# Configure particle behavior
-		particles.emitting = true
-		particles.one_shot = true
-		particles.explosiveness = 0.9
-		particles.amount = particles_per_edge
-		particles.lifetime = strategy.particle_lifetime
-
-		# Particle movement - burst outward from edges
-		particles.direction = dir
-		particles.spread = spread
-		particles.initial_velocity_min = strategy.particle_speed * 0.6
-		particles.initial_velocity_max = strategy.particle_speed
-		particles.gravity = Vector2(0, 150)  # Gentle fall
-
-		# Particle appearance - much larger and visible
-		particles.scale_amount_min = strategy.particle_size_min
-		particles.scale_amount_max = strategy.particle_size_max
-
-		# Color with fade out
-		var gradient: Gradient = Gradient.new()
-		gradient.add_point(0.0, strategy.particle_color)
-		gradient.add_point(0.3, strategy.particle_color)
-		gradient.add_point(1.0, Color(strategy.particle_color.r, strategy.particle_color.g, strategy.particle_color.b, 0.0))
-		particles.color_ramp = gradient
-
-		# Size curve - start big, shrink
-		var scale_curve: Curve = Curve.new()
-		scale_curve.add_point(Vector2(0.0, 1.0))
-		scale_curve.add_point(Vector2(0.5, 0.7))
-		scale_curve.add_point(Vector2(1.0, 0.2))
-		particles.scale_amount_curve = scale_curve
-
-		# Position at edge
-		particles.position = pos
-
-		# Add to tile
-		tile.add_child(particles)
-
-		# Auto-cleanup after particles finish
-		get_tree().create_timer(strategy.particle_lifetime + 0.2).timeout.connect(func():
-			if is_instance_valid(particles):
-				particles.queue_free()
-		)
+func _ensure_draw_resources() -> void:
+	if _draw_animation == null:
+		_draw_animation = DrawTileAnimation.new()
+	if _batch_executor == null:
+		_batch_executor = BatchAnimationExecutor.new(_context)
+
+
+func _ensure_return_resources() -> void:
+	if _return_animation == null:
+		_return_animation = ReturnToHandAnimation.new()
+	if _return_executor == null:
+		_return_executor = ReturnAnimationExecutor.new(_context)
+
+
+func _ensure_shake_resources() -> void:
+	if _shake_animation == null:
+		_shake_animation = ShakeTileAnimation.new()
+	if _shake_executor == null:
+		_shake_executor = ShakeAnimationExecutor.new(_context)
+
+
+func _ensure_stomp_resources() -> void:
+	if _stomp_animation == null:
+		_stomp_animation = StompTileAnimation.new()
+	if _stomp_executor == null:
+		_stomp_executor = StompAnimationExecutor.new(_context)

--- a/project.godot
+++ b/project.godot
@@ -24,6 +24,7 @@ TileBag="*res://autoload/tile_bag.gd"
 HandManager="*res://autoload/hand_manager.gd"
 SelectionManager="*res://autoload/selection_manager.gd"
 TileAnimator="*res://autoload/tile_animator.gd"
+DragManager="*res://autoload/drag_manager.gd"
 
 [dotnet]
 

--- a/scenes/main.gd
+++ b/scenes/main.gd
@@ -19,9 +19,9 @@ enum InteractionMode {
 var selected_tile: Tile = null
 var interaction_mode: InteractionMode = InteractionMode.IDLE
 
-# === Multi-Drag State ===
-var _dragged_tiles: Array[Tile] = []
-var _drag_original_positions: Dictionary = {}  # Tile -> {parent: Node, index: int}
+# === Drag State ===
+# DragManager handles multi-tile drag state
+# Local tracking only for placement success
 var _last_placement_success: bool = false
 
 # === Services ===
@@ -40,7 +40,12 @@ func _ready() -> void:
 	_connect_board_signals()
 	_connect_discard_signals()
 	_connect_hud_signals()
+	_connect_drag_signals()
 	_start_game()
+
+
+func _connect_drag_signals() -> void:
+	DragManager.drag_release_requested.connect(_handle_drag_release)
 
 
 func _unhandled_input(event: InputEvent) -> void:
@@ -136,33 +141,47 @@ func _on_tile_drag_started(tile: Tile) -> void:
 		return
 
 	# Get all selected tiles for multi-drag
-	_dragged_tiles = SelectionManager.get_selected_tiles()
+	var tiles_to_drag: Array[Tile] = SelectionManager.get_selected_tiles()
 
 	# If dragged tile is not in selection, select only it
-	if tile not in _dragged_tiles:
+	if tile not in tiles_to_drag:
 		SelectionManager.deselect_all()
 		SelectionManager.select_tile(tile)
-		_dragged_tiles = [tile]
+		tiles_to_drag = [tile]
 
-	# Store original positions for potential cancellation
-	_store_original_positions()
+	# Mark follower tiles for multi-drag visual
+	for t in tiles_to_drag:
+		if t != tile:
+			t.set_as_drag_follower()
 
-	# Always emit drag started event for discard pile highlighting
-	EventBus.multi_drag_started.emit(_dragged_tiles)
+	# Start drag through DragManager
+	DragManager.start_drag(tile, tiles_to_drag)
 
-	if _dragged_tiles.size() > 1:
-		print("[Main] Multi-drag started with %d tiles" % _dragged_tiles.size())
+	if tiles_to_drag.size() > 1:
+		print("[Main] Multi-drag started with %d tiles" % tiles_to_drag.size())
 
 
 func _on_tile_drag_ended(tile: Tile) -> void:
+	# Only process if this is the lead tile of the current drag
+	if not DragManager.is_dragging:
+		return
+	if tile != DragManager.lead_tile:
+		return
+	_handle_drag_release(tile)
+
+
+## Handles the end of a drag operation (called from tile signal or unhandled input).
+func _handle_drag_release(tile: Tile) -> void:
+	if not DragManager.is_dragging:
+		return
+
+	var dragged_tiles: Array[Tile] = DragManager.get_dragged_tiles()
 	var mouse_pos: Vector2 = get_viewport().get_mouse_position()
 
 	# Check if dropped on discard pile first
 	if discard_pile.is_drop_target(mouse_pos):
-		_handle_drop_on_discard_pile()
-		EventBus.multi_drag_ended.emit(_dragged_tiles, false)
-		_dragged_tiles.clear()
-		_drag_original_positions.clear()
+		_handle_drop_on_discard_pile(dragged_tiles)
+		DragManager.end_drag(false)
 		return
 
 	var cell: BoardCell = _get_cell_under_mouse()
@@ -172,20 +191,17 @@ func _on_tile_drag_ended(tile: Tile) -> void:
 		tile.name,
 		Tile.TileLocation.keys()[tile.location],
 		cell_name,
-		_dragged_tiles.size()
+		dragged_tiles.size()
 	])
 
 	# Handle multi-tile or single-tile drop
-	if _dragged_tiles.size() > 1:
-		_handle_multi_tile_drop(cell)
+	if dragged_tiles.size() > 1:
+		_handle_multi_tile_drop(cell, dragged_tiles)
 	else:
 		_handle_single_tile_drop(tile, cell)
 
-	# Always emit drag ended event for discard pile
-	EventBus.multi_drag_ended.emit(_dragged_tiles, _last_placement_success)
-
-	_dragged_tiles.clear()
-	_drag_original_positions.clear()
+	# End drag operation
+	DragManager.end_drag(_last_placement_success)
 
 
 # === Cell Handlers ===
@@ -364,15 +380,13 @@ func _clear_all_cell_hovers() -> void:
 		cell.clear_hover()
 
 
-func _store_original_positions() -> void:
-	_drag_original_positions.clear()
-	for tile in _dragged_tiles:
-		var parent: Node = tile.get_parent()
-		var index: int = parent.get_children().find(tile) if parent else -1
-		_drag_original_positions[tile] = {"parent": parent, "index": index}
+# Original position tracking is now handled by DragManager
 
 
 func _handle_single_tile_drop(tile: Tile, cell: BoardCell) -> void:
+	# Restore tile to original parent first
+	DragManager.restore_tiles_to_parents()
+
 	# Dropped outside board
 	if cell == null:
 		if tile.location == Tile.TileLocation.ON_BOARD:
@@ -398,29 +412,32 @@ func _handle_single_tile_drop(tile: Tile, cell: BoardCell) -> void:
 	_last_placement_success = true
 
 
-func _handle_multi_tile_drop(start_cell: BoardCell) -> void:
+func _handle_multi_tile_drop(start_cell: BoardCell, tiles: Array[Tile]) -> void:
 	if start_cell == null:
-		_cancel_multi_drag_preserve_selection()
+		_cancel_multi_drag_preserve_selection(tiles)
 		_last_placement_success = false
 		return
 
 	# Validate all tiles can be placed in sequence
-	var cells: Array[BoardCell] = _get_sequential_cells(start_cell, _dragged_tiles.size())
+	var cells: Array[BoardCell] = _get_sequential_cells(start_cell, tiles.size())
 	if cells.is_empty():
-		print("[Main] Cannot place %d tiles starting at %s" % [_dragged_tiles.size(), start_cell.name])
-		_cancel_multi_drag_preserve_selection()
+		print("[Main] Cannot place %d tiles starting at %s" % [tiles.size(), start_cell.name])
+		_cancel_multi_drag_preserve_selection(tiles)
 		_last_placement_success = false
 		return
 
+	# Restore tiles to original parents before placing
+	DragManager.restore_tiles_to_parents()
+
 	# Place all tiles
-	for i in _dragged_tiles.size():
-		_place_tile_on_cell_silent(_dragged_tiles[i], cells[i])
+	for i in tiles.size():
+		_place_tile_on_cell_silent(tiles[i], cells[i])
 
 	# Deselect all after successful placement
 	SelectionManager.deselect_all()
 	_update_interaction_state()
 	_last_placement_success = true
-	print("[Main] Multi-drop: placed %d tiles starting at %s" % [_dragged_tiles.size(), start_cell.name])
+	print("[Main] Multi-drop: placed %d tiles starting at %s" % [tiles.size(), start_cell.name])
 
 
 func _get_sequential_cells(start: BoardCell, count: int) -> Array[BoardCell]:
@@ -437,72 +454,45 @@ func _get_sequential_cells(start: BoardCell, count: int) -> Array[BoardCell]:
 	return cells
 
 
-func _cancel_multi_drag_preserve_selection() -> void:
-	for tile in _dragged_tiles:
-		_return_tile_to_original_position(tile)
+func _cancel_multi_drag_preserve_selection(tiles: Array[Tile]) -> void:
+	# Restore tiles to their original parents via DragManager
+	DragManager.restore_tiles_to_parents()
+
 	# Selection is preserved - tiles remain selected
 	_update_interaction_state()
 	print("[Main] Multi-drag cancelled, selection preserved")
 
 
-func _handle_drop_on_discard_pile() -> void:
+func _handle_drop_on_discard_pile(tiles: Array[Tile]) -> void:
 	# Filter to only hand tiles
 	var hand_tiles: Array[Tile] = []
-	for tile in _dragged_tiles:
+	for tile in tiles:
 		if tile.location == Tile.TileLocation.IN_HAND:
 			hand_tiles.append(tile)
 
 	if hand_tiles.is_empty():
-		# Return board tiles to their cells
-		for tile in _dragged_tiles:
-			if tile.location == Tile.TileLocation.ON_BOARD:
-				_return_to_original_cell(tile)
+		# Return board tiles to their cells via DragManager
+		DragManager.restore_tiles_to_parents()
 		print("[Main] Cannot discard board tiles")
 		return
 
-	# Return tiles to hand first (they may be floating during drag)
-	for tile in hand_tiles:
-		_return_tile_to_original_position(tile)
+	# Return tiles to their original parents via DragManager
+	DragManager.restore_tiles_to_parents()
 
 	# Show confirmation dialog
 	discard_dialog.show_confirmation(hand_tiles.size())
 	print("[Main] Dropped %d tiles on discard pile, awaiting confirmation" % hand_tiles.size())
 
 
-func _return_tile_to_original_position(tile: Tile) -> void:
-	if not _drag_original_positions.has(tile):
-		_cancel_drag_to_hand(tile)
-		return
-
-	var original: Dictionary = _drag_original_positions[tile]
-	var parent: Node = original.get("parent")
-
-	if tile.location == Tile.TileLocation.ON_BOARD:
-		# Was on board - return to cell
-		_return_to_original_cell(tile)
-	else:
-		# Was in hand - return to hand preserving selection
-		if tile.get_parent():
-			tile.get_parent().remove_child(tile)
-		hand.add_tile(tile)
-		tile.location = Tile.TileLocation.IN_HAND
-		tile.current_cell = null
-		tile.modulate = Color.WHITE
-		# Don't deselect - preserve selection
-
-
 func _cancel_drag_to_hand(tile: Tile) -> void:
-	if tile.get_parent():
-		tile.get_parent().remove_child(tile)
-
-	hand.add_tile(tile)
-
+	# Tile was already restored to parent by DragManager.restore_tiles_to_parents()
+	# Just update its state
 	tile.location = Tile.TileLocation.IN_HAND
 	tile.current_cell = null
 	tile.modulate = Color.WHITE
 
-	# Deselect only in single mode or if this is not a multi-drag
-	if not SelectionManager.is_multi_select_enabled() or _dragged_tiles.size() <= 1:
+	# Deselect only in single mode
+	if not SelectionManager.is_multi_select_enabled():
 		SelectionManager.deselect_tile(tile)
 
 	_update_interaction_state()

--- a/scenes/main.gd
+++ b/scenes/main.gd
@@ -1,33 +1,20 @@
 extends Control
 class_name Main
 
-## Main game controller responsible for coordinating game components.
-## Manages tile selection, placement, and overall game interaction flow.
+## Main scene orchestrator.
+## Manages high-level game state and delegates gameplay to controllers.
+## Future: Will handle transitions between menu, gameplay, settings, etc.
 
-# === Signals ===
-signal tile_placement_completed(tile: Tile, cell: BoardCell)
-signal tile_returned_to_hand(tile: Tile)
+# =============================================================================
+# CONTROLLERS
+# =============================================================================
 
-# === Interaction State Machine ===
-enum InteractionMode {
-	IDLE,           # No tile selected, waiting for input
-	TILE_SELECTED,  # Tile selected from hand, waiting for placement
-	DRAGGING        # Tile being dragged
-}
+var _gameplay_controller: GameplayController = null
 
-# === State ===
-var selected_tile: Tile = null
-var interaction_mode: InteractionMode = InteractionMode.IDLE
+# =============================================================================
+# NODE REFERENCES
+# =============================================================================
 
-# === Drag State ===
-# DragManager handles multi-tile drag state
-# Local tracking only for placement success
-var _last_placement_success: bool = false
-
-# === Services ===
-var _word_validator: WordValidator = null
-
-# === Node References ===
 @onready var board: Board = $Board
 @onready var hand: Hand = $Hand
 @onready var discard_pile: Control = $DiscardPile
@@ -35,657 +22,61 @@ var _word_validator: WordValidator = null
 @onready var main_hud: CanvasLayer = $MainHUD
 
 
+# =============================================================================
+# LIFECYCLE
+# =============================================================================
+
 func _ready() -> void:
-	_word_validator = WordValidator.new()
-	_connect_board_signals()
-	_connect_discard_signals()
-	_connect_hud_signals()
-	_connect_drag_signals()
+	_setup_controllers()
 	_start_game()
 
 
-func _connect_drag_signals() -> void:
-	DragManager.drag_release_requested.connect(_handle_drag_release)
+func _setup_controllers() -> void:
+	# Create and configure gameplay controller
+	_gameplay_controller = GameplayController.new()
+	add_child(_gameplay_controller)
 
+	# Inject dependencies
+	_gameplay_controller.setup(board, hand, discard_pile, discard_dialog, main_hud)
 
-func _unhandled_input(event: InputEvent) -> void:
-	if event.is_action_pressed("toggle_multi_select"):
-		SelectionManager.toggle_mode()
-
-	if event.is_action_pressed("discard_tiles"):
-		_request_discard_confirmation()
-
-
-func _process(_delta: float) -> void:
-	pass
-
-
-# === Initialization ===
-
-func _connect_board_signals() -> void:
-	# Wait for board to initialize
-	if not board.is_node_ready():
-		await board.ready
-
-	# Connect to board's forwarded signals
-	board.cell_clicked.connect(_on_cell_clicked)
-	board.cell_hovered.connect(_on_cell_hovered)
-	board.cell_unhovered.connect(_on_cell_unhovered)
-
-
-func _connect_discard_signals() -> void:
-	discard_pile.tiles_dropped.connect(_on_discard_pile_tiles_dropped)
-	discard_pile.peek_requested.connect(_on_discard_pile_peek_requested)
-	discard_dialog.confirmed.connect(_on_discard_confirmed)
-	discard_dialog.cancelled.connect(_on_discard_cancelled)
-
-
-func _connect_hud_signals() -> void:
-	main_hud.play_requested.connect(_on_play_requested)
+	# Connect controller signals if needed
+	_gameplay_controller.play_completed.connect(_on_play_completed)
 
 
 func _start_game() -> void:
 	var default_bag: BagDistribution = load("res://Data/BagDistribution/bag_default.tres")
 	GameManager.start_game(default_bag, 0)
 
-
-# === Tile Selection Handlers ===
-
-func _on_tile_selected(tile: Tile) -> void:
-	print("[Main] Tile selected: %s" % tile.name)
-
-	# Clicking a board tile while we have selection
-	if SelectionManager.has_selection() and tile.location == Tile.TileLocation.ON_BOARD:
-		print("[Main] Cannot stack tiles")
-		return
-
-	# Clicking a tile that's already on the board (info only)
-	if not SelectionManager.has_selection() and tile.location == Tile.TileLocation.ON_BOARD:
-		print("[Main] Board tile at cell: %s" % tile.current_cell.name)
-		return
-
-	# Hand tile - use SelectionManager
-	if tile.location == Tile.TileLocation.IN_HAND:
-		SelectionManager.select_tile(tile)
-		_update_interaction_state()
-
-
-func _on_tile_right_clicked(tile: Tile) -> void:
-	if SelectionManager.has_selection():
-		print("[Main] Cannot remove tile while selection active")
-		return
-
-	if tile.current_cell == null:
-		print("[Main] Tile is not on board")
-		return
-
-	# Check if tile is locked (already played)
-	if tile.is_locked:
-		print("[Main] Cannot return tile - tile is locked (already played)")
-		TileAnimator.animate_shake(tile)
-		return
-
-	# Check if hand has space for the tile
-	if hand.is_full():
-		print("[Main] Cannot return tile - hand is full")
-		TileAnimator.animate_shake(tile)
-		return
-
-	return_tile_to_hand(tile)
-
-
-func _on_tile_drag_started(tile: Tile) -> void:
-	# Prevent dragging locked tiles
-	if tile.is_locked:
-		print("[Main] Cannot drag locked tile: %s" % tile.name)
-		return
-
-	# Get all selected tiles for multi-drag
-	var tiles_to_drag: Array[Tile] = SelectionManager.get_selected_tiles()
-
-	# If dragged tile is not in selection, select only it
-	if tile not in tiles_to_drag:
-		SelectionManager.deselect_all()
-		SelectionManager.select_tile(tile)
-		tiles_to_drag = [tile]
-
-	# Mark follower tiles for multi-drag visual
-	for t in tiles_to_drag:
-		if t != tile:
-			t.set_as_drag_follower()
-
-	# Start drag through DragManager
-	DragManager.start_drag(tile, tiles_to_drag)
-
-	if tiles_to_drag.size() > 1:
-		print("[Main] Multi-drag started with %d tiles" % tiles_to_drag.size())
-
-
-func _on_tile_drag_ended(tile: Tile) -> void:
-	# Only process if this is the lead tile of the current drag
-	if not DragManager.is_dragging:
-		return
-	if tile != DragManager.lead_tile:
-		return
-	_handle_drag_release(tile)
-
-
-## Handles the end of a drag operation (called from tile signal or unhandled input).
-func _handle_drag_release(tile: Tile) -> void:
-	if not DragManager.is_dragging:
-		return
-
-	var dragged_tiles: Array[Tile] = DragManager.get_dragged_tiles()
-	var mouse_pos: Vector2 = get_viewport().get_mouse_position()
-
-	# Check if dropped on discard pile first
-	if discard_pile.is_drop_target(mouse_pos):
-		_handle_drop_on_discard_pile(dragged_tiles)
-		DragManager.end_drag(false)
-		return
-
-	var cell: BoardCell = _get_cell_under_mouse()
-
-	var cell_name: String = String(cell.name) if cell else "none"
-	print("[Main] Drag ended - Tile: %s | Location: %s | Cell: %s | Multi: %d" % [
-		tile.name,
-		Tile.TileLocation.keys()[tile.location],
-		cell_name,
-		dragged_tiles.size()
-	])
-
-	# Handle multi-tile or single-tile drop
-	if dragged_tiles.size() > 1:
-		_handle_multi_tile_drop(cell, dragged_tiles)
-	else:
-		_handle_single_tile_drop(tile, cell)
-
-	# End drag operation
-	DragManager.end_drag(_last_placement_success)
-
-
-# === Cell Handlers ===
-
-func _on_cell_clicked(cell: BoardCell) -> void:
-	var selected_tiles: Array[Tile] = SelectionManager.get_selected_tiles()
-
-	if selected_tiles.is_empty():
-		print("[Main] No tile selected")
-		return
-
-	if cell.is_occupied():
-		print("[Main] Cell occupied: %s" % cell.name)
-		return
-
-	# Multi-tile click placement
-	if selected_tiles.size() > 1:
-		var cells: Array[BoardCell] = _get_sequential_cells(cell, selected_tiles.size())
-		if cells.is_empty():
-			print("[Main] Cannot place %d tiles starting at %s" % [selected_tiles.size(), cell.name])
-			return
-
-		# Place all tiles
-		for i in selected_tiles.size():
-			_place_tile_on_cell_silent(selected_tiles[i], cells[i])
-
-		SelectionManager.deselect_all()
-		_update_interaction_state()
-		print("[Main] Placed %d tiles starting at %s" % [selected_tiles.size(), cell.name])
-	else:
-		# Single tile placement
-		place_tile_on_cell(selected_tiles[0], cell)
-
-
-func _on_cell_hovered(cell: BoardCell) -> void:
-	if not SelectionManager.has_selection():
-		return
-
-	var selected_count: int = SelectionManager.get_selection_count()
-
-	if selected_count > 1:
-		# Multi-tile hover - check if all sequential cells are valid
-		var cells: Array[BoardCell] = _get_sequential_cells(cell, selected_count)
-		if cells.is_empty():
-			cell.show_invalid_hover()
-		else:
-			# Show valid hover on all cells that would be used
-			for c in cells:
-				c.show_valid_hover()
-	else:
-		# Single tile hover
-		if cell.is_occupied():
-			cell.show_invalid_hover()
-		else:
-			cell.show_valid_hover()
-
-
-func _on_cell_unhovered(cell: BoardCell) -> void:
-	cell.clear_hover()
-
-
-# === Tile Placement ===
-
-func place_tile_on_cell(tile: Tile, cell: BoardCell) -> void:
-	if cell.is_occupied():
-		return
-
-	_place_tile_on_cell_silent(tile, cell)
-
-	# Deselect and reset interaction
-	SelectionManager.deselect_tile(tile)
-	_update_interaction_state()
-
-
-## Places a tile on a cell without deselecting or updating interaction state.
-## Used for multi-tile placement where we batch the state updates.
-func _place_tile_on_cell_silent(tile: Tile, cell: BoardCell) -> void:
-	if cell.is_occupied():
-		return
-
-	# Clear old cell if tile was on board
-	if tile.location == Tile.TileLocation.ON_BOARD and tile.current_cell != null:
-		var old_cell: BoardCell = tile.current_cell
-		old_cell.tile = null
-		print("[Main] Cleared old cell: %s" % old_cell.name)
-
-	# Reparent tile to cell
-	tile.get_parent().remove_child(tile)
-	cell.tile_anchor.add_child(tile)
-	tile.position = Vector2.ZERO
-
-	# Update tile state
-	tile.current_cell = cell
-	tile.location = Tile.TileLocation.ON_BOARD
-
-	# Update cell state
-	cell.tile = tile
-
-	_clear_all_cell_hovers()
-
-	EventBus.tile_placed.emit(tile, cell)
-	tile_placement_completed.emit(tile, cell)
-	_update_play_button_state()
-	print("[Main] Placed tile %s on cell %s" % [tile.name, cell.name])
-
-
-func return_tile_to_hand(tile: Tile) -> void:
-	_return_tile_to_hand_internal(tile, false)
-
-
-func _return_tile_to_hand_internal(tile: Tile, preserve_selection: bool) -> void:
-	if tile.current_cell == null and tile.location != Tile.TileLocation.IN_HAND:
-		# Tile being returned from drag, not from board
-		if tile.get_parent():
-			tile.get_parent().remove_child(tile)
-		hand.add_tile(tile)
-		tile.location = Tile.TileLocation.IN_HAND
-		tile.modulate = Color.WHITE
-		if not preserve_selection:
-			SelectionManager.deselect_tile(tile)
-		return
-
-	if tile.current_cell == null:
-		return
-
-	var cell: BoardCell = tile.current_cell
-
-	# Use animated return - TileAnimator handles the tile movement
-	TileAnimator.animate_return_to_hand(tile, hand, cell)
-
-	if not preserve_selection:
-		SelectionManager.deselect_tile(tile)
-
-	_update_interaction_state()
-	_clear_all_cell_hovers()
-
-	EventBus.tile_removed.emit(tile, cell)
-	tile_returned_to_hand.emit(tile)
-	_update_play_button_state()
-	print("[Main] Returned tile %s from cell %s to hand (animated)" % [tile.name, cell.name])
-
-
-# === Private Helpers ===
-
-func _update_interaction_state() -> void:
-	var has_selection: bool = SelectionManager.has_selection()
-
-	if has_selection:
-		interaction_mode = InteractionMode.TILE_SELECTED
-		selected_tile = SelectionManager.get_selected_tiles()[0] if SelectionManager.get_selection_count() == 1 else null
-		_set_hand_tiles_hover_enabled(false)
-	else:
-		interaction_mode = InteractionMode.IDLE
-		selected_tile = null
-		_set_hand_tiles_hover_enabled(true)
-		_clear_all_cell_hovers()
-
-
-func _deselect_tile() -> void:
-	SelectionManager.deselect_all()
-	_update_interaction_state()
-
-
-func _set_hand_tiles_hover_enabled(enabled: bool) -> void:
-	for tile in hand.get_tiles():
-		tile.allow_hover_feedback = enabled
-
-
-func _get_cell_under_mouse() -> BoardCell:
-	var mouse_pos: Vector2 = get_viewport().get_mouse_position()
-	return board.get_cell_at_position(mouse_pos)
-
-
-func _clear_all_cell_hovers() -> void:
-	for cell in board.get_all_cells():
-		cell.clear_hover()
-
-
-# Original position tracking is now handled by DragManager
-
-
-func _handle_single_tile_drop(tile: Tile, cell: BoardCell) -> void:
-	# Restore tile to original parent first
-	DragManager.restore_tiles_to_parents()
-
-	# Dropped outside board
-	if cell == null:
-		if tile.location == Tile.TileLocation.ON_BOARD:
-			_return_to_original_cell(tile)
-		else:
-			_cancel_drag_to_hand(tile)
-		_last_placement_success = false
-		return
-
-	# Dropped on occupied cell
-	if cell.is_occupied():
-		print("[Main] Cannot drop on occupied cell: %s" % cell.name)
-		if tile.location == Tile.TileLocation.ON_BOARD:
-			_return_to_original_cell(tile)
-		else:
-			_cancel_drag_to_hand(tile)
-		_last_placement_success = false
-		return
-
-	# Valid placement
-	print("[Main] Valid drop on cell: %s" % cell.name)
-	place_tile_on_cell(tile, cell)
-	_last_placement_success = true
-
-
-func _handle_multi_tile_drop(drop_cell: BoardCell, tiles: Array[Tile]) -> void:
-	if drop_cell == null:
-		_cancel_multi_drag_preserve_selection(tiles)
-		_last_placement_success = false
-		return
-
-	# Find which tile in the selection is the lead (the one being dragged)
-	var lead_tile: Tile = DragManager.lead_tile
-	var lead_index: int = tiles.find(lead_tile)
-	if lead_index == -1:
-		lead_index = 0  # Fallback to first tile
-
-	# Calculate the actual starting position based on lead tile's position in selection
-	# If lead is at index 2 and we drop on cell (3,4), first tile goes at (1,4)
-	var cells: Array[BoardCell] = _get_sequential_cells_centered(drop_cell, tiles.size(), lead_index)
-	if cells.is_empty():
-		print("[Main] Cannot place %d tiles centered at %s (lead index: %d)" % [tiles.size(), drop_cell.name, lead_index])
-		_cancel_multi_drag_preserve_selection(tiles)
-		_last_placement_success = false
-		return
-
-	# Restore tiles to original parents before placing
-	DragManager.restore_tiles_to_parents()
-
-	# Place all tiles
-	for i in tiles.size():
-		_place_tile_on_cell_silent(tiles[i], cells[i])
-
-	# Deselect all after successful placement
-	SelectionManager.deselect_all()
-	_update_interaction_state()
-	_last_placement_success = true
-	print("[Main] Multi-drop: placed %d tiles centered at %s" % [tiles.size(), drop_cell.name])
-
-
-func _get_sequential_cells(start: BoardCell, count: int) -> Array[BoardCell]:
-	var cells: Array[BoardCell] = []
-	var pos: Vector2i = start.grid_position
-	var direction: Vector2i = Vector2i.RIGHT  # Future: configurable direction
-
-	for i in count:
-		var cell: BoardCell = board.get_cell(pos.y, pos.x)
-		if cell == null or cell.is_occupied():
-			return []  # Invalid - return empty
-		cells.append(cell)
-		pos += direction
-	return cells
-
-
-## Gets sequential cells centered around a drop position based on lead tile index.
-## Example: If dropping 3 tiles [A,B,C] by dragging B (index 1) onto cell (3,4):
-##   - A goes at (2,4) - one cell LEFT of drop
-##   - B goes at (3,4) - the drop cell
-##   - C goes at (4,4) - one cell RIGHT of drop
-func _get_sequential_cells_centered(drop_cell: BoardCell, count: int, lead_index: int) -> Array[BoardCell]:
-	var cells: Array[BoardCell] = []
-	var drop_pos: Vector2i = drop_cell.grid_position
-	var direction: Vector2i = Vector2i.RIGHT
-
-	# Calculate starting position: move LEFT by lead_index cells
-	var start_pos: Vector2i = drop_pos - (direction * lead_index)
-
-	for i in count:
-		var pos: Vector2i = start_pos + (direction * i)
-		var cell: BoardCell = board.get_cell(pos.y, pos.x)
-		if cell == null or cell.is_occupied():
-			return []  # Invalid - return empty
-		cells.append(cell)
-
-	return cells
-
-
-func _cancel_multi_drag_preserve_selection(tiles: Array[Tile]) -> void:
-	# Restore tiles to their original parents via DragManager
-	DragManager.restore_tiles_to_parents()
-
-	# Selection is preserved - tiles remain selected
-	_update_interaction_state()
-	print("[Main] Multi-drag cancelled, selection preserved")
-
-
-func _handle_drop_on_discard_pile(tiles: Array[Tile]) -> void:
-	# Filter to only hand tiles
-	var hand_tiles: Array[Tile] = []
-	for tile in tiles:
-		if tile.location == Tile.TileLocation.IN_HAND:
-			hand_tiles.append(tile)
-
-	if hand_tiles.is_empty():
-		# Return board tiles to their cells via DragManager
-		DragManager.restore_tiles_to_parents()
-		print("[Main] Cannot discard board tiles")
-		return
-
-	# Return tiles to their original parents via DragManager
-	DragManager.restore_tiles_to_parents()
-
-	# Show confirmation dialog
-	discard_dialog.show_confirmation(hand_tiles.size())
-	print("[Main] Dropped %d tiles on discard pile, awaiting confirmation" % hand_tiles.size())
-
-
-func _cancel_drag_to_hand(tile: Tile) -> void:
-	# Tile was already restored to parent by DragManager.restore_tiles_to_parents()
-	# Just update its state
-	tile.location = Tile.TileLocation.IN_HAND
-	tile.current_cell = null
-	tile.modulate = Color.WHITE
-
-	# Deselect only in single mode
-	if not SelectionManager.is_multi_select_enabled():
-		SelectionManager.deselect_tile(tile)
-
-	_update_interaction_state()
-	_clear_all_cell_hovers()
-
-	print("[Main] Cancelled drag for tile: %s" % tile.name)
-
-
-func _return_to_original_cell(tile: Tile) -> void:
-	if tile.current_cell == null:
-		push_error("[Main] Board tile has no current_cell reference!")
-		return
-
-	tile.position = Vector2.ZERO
-	tile.modulate = Color.WHITE
-
-	print("[Main] Tile %s returned to cell: %s" % [tile.name, tile.current_cell.name])
-
-
-# === Discard Handlers ===
-
-func _request_discard_confirmation() -> void:
-	var selected_tiles: Array[Tile] = SelectionManager.get_selected_tiles()
-
-	# Filter to only hand tiles
-	var hand_tiles: Array[Tile] = []
-	for tile in selected_tiles:
-		if tile.location == Tile.TileLocation.IN_HAND:
-			hand_tiles.append(tile)
-
-	if hand_tiles.is_empty():
-		print("[Main] No hand tiles selected to discard")
-		return
-
-	discard_dialog.show_confirmation(hand_tiles.size())
-	EventBus.discard_confirmation_requested.emit(hand_tiles.size())
-
-
-func _on_discard_confirmed() -> void:
-	var selected_tiles: Array[Tile] = SelectionManager.get_selected_tiles()
-
-	# Filter to only hand tiles
-	var hand_tiles: Array[Tile] = []
-	for tile in selected_tiles:
-		if tile.location == Tile.TileLocation.IN_HAND:
-			hand_tiles.append(tile)
-
-	if hand_tiles.is_empty():
-		return
-
-	# Discard all selected hand tiles
-	_discard_tiles(hand_tiles)
-
-	EventBus.discard_confirmed.emit()
-	print("[Main] Discard confirmed: %d tiles" % hand_tiles.size())
-
-
-func _on_discard_cancelled() -> void:
-	# Selection is preserved when user cancels
-	EventBus.discard_cancelled.emit()
-	print("[Main] Discard cancelled, selection preserved")
-
-
-func _on_discard_pile_tiles_dropped(tiles: Array) -> void:
-	# Filter to only hand tiles
-	var hand_tiles: Array[Tile] = []
-	for tile in tiles:
-		if tile is Tile and tile.location == Tile.TileLocation.IN_HAND:
-			hand_tiles.append(tile)
-
-	if hand_tiles.is_empty():
-		return
-
-	# Show confirmation before discarding
-	discard_dialog.show_confirmation(hand_tiles.size())
-
-
-func _on_discard_pile_peek_requested() -> void:
-	# Future feature: show discard pile contents
-	var pile: Array[Tile] = HandManager.get_discard_pile()
-	print("[Main] Peek requested - Discard pile has %d tiles" % pile.size())
-	# TODO: Show discard pile viewer UI
-
-
-func _discard_tiles(tiles: Array[Tile]) -> void:
-	# Deselect all tiles first
-	SelectionManager.deselect_all()
-
-	# Discard each tile through HandManager
-	for tile in tiles:
-		HandManager.discard_tile(tile)
-
-	# Refill hand from tile bag
-	var refilled: int = HandManager.refill_hand()
-	print("[Main] Discarded %d tiles, refilled %d" % [tiles.size(), refilled])
-
-	_update_interaction_state()
+	# Activate gameplay controller
+	_gameplay_controller.activate()
 
 
 # =============================================================================
-# PLAY HANDLERS
+# GAME STATE MANAGEMENT
 # =============================================================================
 
-func _on_play_requested() -> void:
-	print("[Main] Play requested")
-
-	# Get unplayed tiles on the board
-	var unplayed_tiles: Array[Tile] = _get_unplayed_board_tiles()
-
-	if unplayed_tiles.is_empty():
-		print("[Main] No tiles to play")
-		return
-
-	# Get positions of unplayed tiles
-	var positions: Array[Vector2i] = []
-	for tile in unplayed_tiles:
-		if tile.current_cell:
-			positions.append(tile.current_cell.grid_position)
-
-	# Find all words formed by the placement
-	var words: Array = _word_validator.find_formed_words(board, positions)
-
-	print("[Main] Found %d words from %d tiles" % [words.size(), unplayed_tiles.size()])
-	for word_info in words:
-		print("[Main] Word: '%s' (%s)" % [word_info.word, word_info.direction])
-
-	# Lock all placed tiles (make them permanent)
-	for tile in unplayed_tiles:
-		tile.is_locked = true
-		print("[Main] Locked tile: %s" % tile.name)
-
-	# Play stomp animation
-	TileAnimator.animate_stomp_batch(unplayed_tiles)
-
-	# Emit event
-	EventBus.tiles_played.emit(unplayed_tiles, words)
-
-	# Update play button state
-	_update_play_button_state()
-
-	# For now, just log - score calculation will be added later
-	print("[Main] Played %d tiles, formed %d words" % [unplayed_tiles.size(), words.size()])
+## Called when tiles are played (locked on board).
+func _on_play_completed(tiles: Array[Tile], words: Array) -> void:
+	# Future: Update score, check win conditions, etc.
+	print("[Main] Play completed: %d tiles, %d words" % [tiles.size(), words.size()])
 
 
-## Returns all tiles on the board that haven't been played yet (not locked).
-func _get_unplayed_board_tiles() -> Array[Tile]:
-	var tiles: Array[Tile] = []
-	for cell in board.get_all_cells():
-		if cell.is_occupied() and not cell.tile.is_locked:
-			tiles.append(cell.tile)
-	return tiles
+## Pauses gameplay (e.g., for menus or dialogs).
+func pause_gameplay() -> void:
+	_gameplay_controller.deactivate()
 
 
-## Returns all tiles currently placed on the board.
-func _get_all_board_tiles() -> Array[Tile]:
-	var tiles: Array[Tile] = []
-	for cell in board.get_all_cells():
-		if cell.is_occupied():
-			tiles.append(cell.tile)
-	return tiles
+## Resumes gameplay.
+func resume_gameplay() -> void:
+	_gameplay_controller.activate()
 
 
-## Updates the play button enabled state based on whether there are unplayed tiles.
-func _update_play_button_state() -> void:
-	var has_unplayed_tiles: bool = not _get_unplayed_board_tiles().is_empty()
-	main_hud.set_play_button_enabled(has_unplayed_tiles)
+# =============================================================================
+# PUBLIC API - For external systems
+# =============================================================================
+
+## Registers a tile with the gameplay controller.
+## Called by HandManager when tiles are created.
+func register_tile(tile: Tile) -> void:
+	if _gameplay_controller:
+		_gameplay_controller.register_tile(tile)

--- a/scenes/main.gd
+++ b/scenes/main.gd
@@ -412,16 +412,23 @@ func _handle_single_tile_drop(tile: Tile, cell: BoardCell) -> void:
 	_last_placement_success = true
 
 
-func _handle_multi_tile_drop(start_cell: BoardCell, tiles: Array[Tile]) -> void:
-	if start_cell == null:
+func _handle_multi_tile_drop(drop_cell: BoardCell, tiles: Array[Tile]) -> void:
+	if drop_cell == null:
 		_cancel_multi_drag_preserve_selection(tiles)
 		_last_placement_success = false
 		return
 
-	# Validate all tiles can be placed in sequence
-	var cells: Array[BoardCell] = _get_sequential_cells(start_cell, tiles.size())
+	# Find which tile in the selection is the lead (the one being dragged)
+	var lead_tile: Tile = DragManager.lead_tile
+	var lead_index: int = tiles.find(lead_tile)
+	if lead_index == -1:
+		lead_index = 0  # Fallback to first tile
+
+	# Calculate the actual starting position based on lead tile's position in selection
+	# If lead is at index 2 and we drop on cell (3,4), first tile goes at (1,4)
+	var cells: Array[BoardCell] = _get_sequential_cells_centered(drop_cell, tiles.size(), lead_index)
 	if cells.is_empty():
-		print("[Main] Cannot place %d tiles starting at %s" % [tiles.size(), start_cell.name])
+		print("[Main] Cannot place %d tiles centered at %s (lead index: %d)" % [tiles.size(), drop_cell.name, lead_index])
 		_cancel_multi_drag_preserve_selection(tiles)
 		_last_placement_success = false
 		return
@@ -437,7 +444,7 @@ func _handle_multi_tile_drop(start_cell: BoardCell, tiles: Array[Tile]) -> void:
 	SelectionManager.deselect_all()
 	_update_interaction_state()
 	_last_placement_success = true
-	print("[Main] Multi-drop: placed %d tiles starting at %s" % [tiles.size(), start_cell.name])
+	print("[Main] Multi-drop: placed %d tiles centered at %s" % [tiles.size(), drop_cell.name])
 
 
 func _get_sequential_cells(start: BoardCell, count: int) -> Array[BoardCell]:
@@ -451,6 +458,29 @@ func _get_sequential_cells(start: BoardCell, count: int) -> Array[BoardCell]:
 			return []  # Invalid - return empty
 		cells.append(cell)
 		pos += direction
+	return cells
+
+
+## Gets sequential cells centered around a drop position based on lead tile index.
+## Example: If dropping 3 tiles [A,B,C] by dragging B (index 1) onto cell (3,4):
+##   - A goes at (2,4) - one cell LEFT of drop
+##   - B goes at (3,4) - the drop cell
+##   - C goes at (4,4) - one cell RIGHT of drop
+func _get_sequential_cells_centered(drop_cell: BoardCell, count: int, lead_index: int) -> Array[BoardCell]:
+	var cells: Array[BoardCell] = []
+	var drop_pos: Vector2i = drop_cell.grid_position
+	var direction: Vector2i = Vector2i.RIGHT
+
+	# Calculate starting position: move LEFT by lead_index cells
+	var start_pos: Vector2i = drop_pos - (direction * lead_index)
+
+	for i in count:
+		var pos: Vector2i = start_pos + (direction * i)
+		var cell: BoardCell = board.get_cell(pos.y, pos.x)
+		if cell == null or cell.is_occupied():
+			return []  # Invalid - return empty
+		cells.append(cell)
+
 	return cells
 
 

--- a/scenes/tile/tile.gd
+++ b/scenes/tile/tile.gd
@@ -180,15 +180,7 @@ func set_as_drag_follower() -> void:
 	allow_hover_feedback = false
 
 
-## Ends the drag state for follower tiles.
-func end_drag_follower() -> void:
-	_drag_state = DragState.IDLE
-	_is_lead_tile = false
-	allow_hover_feedback = true
-	modulate = Color.WHITE
-
-
-## Force-resets all drag state (called by DragManager when drag is cancelled externally).
+## Force-resets all drag state (called by DragManager for all tiles when drag ends).
 func force_end_drag() -> void:
 	_drag_state = DragState.IDLE
 	_is_lead_tile = false

--- a/scenes/tile/tile.gd
+++ b/scenes/tile/tile.gd
@@ -59,6 +59,7 @@ var _drag_state: DragState = DragState.IDLE
 var _drag_offset: Vector2 = Vector2.ZERO
 var _press_position: Vector2 = Vector2.ZERO
 var _original_z_index: int = 0
+var _is_lead_tile: bool = false  # True if this tile is being directly dragged
 
 # === Pending initialization (applied in _ready) ===
 var _pending_texture: Texture2D = null
@@ -80,7 +81,9 @@ func _ready() -> void:
 
 
 func _process(_delta: float) -> void:
-	if _drag_state == DragState.DRAGGING:
+	# Only update position if we're the lead tile (directly dragged)
+	# DragManager handles positioning for follower tiles
+	if _drag_state == DragState.DRAGGING and _is_lead_tile:
 		global_position = get_global_mouse_position() - _drag_offset
 
 
@@ -166,7 +169,32 @@ func reset() -> void:
 	selection_order = -1
 	scale = NORMAL_SCALE
 	_drag_state = DragState.IDLE
+	_is_lead_tile = false
 	_update_visual()
+
+
+## Sets this tile as a follower in a multi-drag (not directly dragged).
+func set_as_drag_follower() -> void:
+	_drag_state = DragState.DRAGGING
+	_is_lead_tile = false
+	allow_hover_feedback = false
+
+
+## Ends the drag state for follower tiles.
+func end_drag_follower() -> void:
+	_drag_state = DragState.IDLE
+	_is_lead_tile = false
+	allow_hover_feedback = true
+	modulate = Color.WHITE
+
+
+## Force-resets all drag state (called by DragManager when drag is cancelled externally).
+func force_end_drag() -> void:
+	_drag_state = DragState.IDLE
+	_is_lead_tile = false
+	allow_hover_feedback = true
+	modulate = Color.WHITE
+	z_index = 0
 
 
 # === Private: Input Handling ===
@@ -217,6 +245,7 @@ func _on_release() -> void:
 
 func _start_drag() -> void:
 	_drag_state = DragState.DRAGGING
+	_is_lead_tile = true  # We're the directly dragged tile
 	allow_hover_feedback = false
 
 	_original_z_index = z_index
@@ -234,6 +263,7 @@ func _start_drag() -> void:
 
 func _end_drag() -> void:
 	z_index = _original_z_index
+	_is_lead_tile = false
 
 	var cell_info: String = String(current_cell.name) if current_cell else "none"
 	print("[Tile] Drag end: %s | Location: %s | Cell: %s" % [

--- a/scripts/animation/AGENT.md
+++ b/scripts/animation/AGENT.md
@@ -10,7 +10,14 @@ scripts/animation/
 ├── draw_tile_animation.gd        # Draw animation implementation
 ├── return_to_hand_animation.gd   # Return from board animation
 ├── shake_tile_animation.gd       # Illegal action feedback animation
-└── stomp_tile_animation.gd       # Play confirmation animation
+├── stomp_tile_animation.gd       # Play confirmation animation
+└── executors/
+    ├── animation_context.gd      # Shared state for executors
+    ├── animation_executor.gd     # Base executor class
+    ├── batch_animation_executor.gd    # Staggered batch animations
+    ├── return_animation_executor.gd   # Return/cancel animations
+    ├── shake_animation_executor.gd    # Shake effect executor
+    └── stomp_animation_executor.gd    # Stomp with particles executor
 ```
 
 ---
@@ -227,6 +234,54 @@ TileAnimator.animate_stomp_batch(tiles)
 
 ---
 
+## Animation Executors
+
+### Purpose
+Executors encapsulate animation execution logic, keeping TileAnimator as a thin facade. Each executor handles one type of animation, sharing state via AnimationContext.
+
+### AnimationContext
+Shared state container passed to all executors:
+```gdscript
+class_name AnimationContext
+
+var active_tweens: Dictionary = {}  # Tile -> Tween
+var is_animating: bool = false
+
+# Signal callbacks (set by TileAnimator)
+func emit_animation_started(tiles: Array[Tile]) -> void
+func emit_animation_completed(tiles: Array[Tile]) -> void
+func emit_single_tile_animated(tile: Tile) -> void
+
+# Utilities
+func create_tween() -> Tween
+func get_tree() -> SceneTree
+func cancel_tile_animation(tile: Tile) -> void
+```
+
+### AnimationExecutor (Base Class)
+Common helpers for all executors:
+```gdscript
+class_name AnimationExecutor
+
+var _context: AnimationContext
+
+func _apply_properties(tile: Tile, properties: Dictionary) -> void
+func _register_tween(tile: Tile, tween: Tween) -> void
+func _unregister_tween(tile: Tile) -> void
+func _create_batch_completion_callback(...) -> Callable
+func _create_single_completion_callback(...) -> Callable
+```
+
+### Executor Classes
+| Executor | Strategy | Purpose |
+|----------|----------|---------|
+| BatchAnimationExecutor | TileAnimationStrategy | Staggered batch property tweens |
+| ReturnAnimationExecutor | TileAnimationStrategy | Return-to-hand and cancel animations |
+| ShakeAnimationExecutor | ShakeTileAnimation | Shake effect for illegal actions |
+| StompAnimationExecutor | StompTileAnimation | Stomp with particle spawning |
+
+---
+
 ## Creating New Animations
 
 ### Step 1: Create Strategy Class
@@ -240,36 +295,56 @@ func _init() -> void:
     trans_type = Tween.TRANS_QUAD
 
 func get_start_position_offset() -> Vector2:
-    return Vector2.ZERO  # Start at current position
+    return Vector2.ZERO
 
 func get_start_properties() -> Dictionary:
-    return {
-        "scale": Vector2.ONE,
-        "modulate": Color.WHITE
-    }
+    return {"scale": Vector2.ONE, "modulate": Color.WHITE}
 
 func get_end_properties() -> Dictionary:
-    return {
-        "scale": Vector2(0.5, 0.5),
-        "modulate": Color(1.0, 1.0, 1.0, 0.0)
-    }
+    return {"scale": Vector2(0.5, 0.5), "modulate": Color(1, 1, 1, 0)}
 ```
 
-### Step 2: Add Method to TileAnimator
+### Step 2: Create Executor (if needed)
+For simple animations, use BatchAnimationExecutor. For complex animations:
+```gdscript
+extends AnimationExecutor
+class_name DiscardAnimationExecutor
+
+func execute(tiles: Array[Tile], strategy: DiscardTileAnimation) -> void:
+    _context.is_animating = true
+    _context.emit_animation_started(tiles)
+
+    # Custom animation logic...
+
+    for tile in tiles:
+        var tween: Tween = _context.create_tween()
+        # ... configure tween ...
+        _register_tween(tile, tween)
+        tween.finished.connect(_create_single_completion_callback(tile, strategy))
+```
+
+### Step 3: Add to TileAnimator
 ```gdscript
 # In tile_animator.gd
 var _discard_animation: DiscardTileAnimation = null
+var _discard_executor: DiscardAnimationExecutor = null
 
-func animate_discard_batch(tiles: Array[Tile]) -> void:
+func animate_discard(tiles: Array[Tile]) -> void:
+    if tiles.is_empty():
+        return
+    _ensure_discard_resources()
+    _discard_executor.execute(tiles, _discard_animation)
+
+func _ensure_discard_resources() -> void:
     if _discard_animation == null:
         _discard_animation = DiscardTileAnimation.new()
-    _animate_batch(tiles, _discard_animation)
+    if _discard_executor == null:
+        _discard_executor = DiscardAnimationExecutor.new(_context)
 ```
 
-### Step 3: Call from Manager
+### Step 4: Call from Manager
 ```gdscript
-# In hand_manager.gd or main.gd
-TileAnimator.animate_discard_batch(tiles_to_discard)
+TileAnimator.animate_discard(tiles_to_discard)
 ```
 
 ---

--- a/scripts/animation/executors/animation_context.gd
+++ b/scripts/animation/executors/animation_context.gd
@@ -1,0 +1,82 @@
+extends RefCounted
+class_name AnimationContext
+
+## Shared context for animation executors.
+## Contains state and signal emission callbacks.
+
+# =============================================================================
+# STATE
+# =============================================================================
+
+var active_tweens: Dictionary = {}  # Tile -> Tween
+var is_animating: bool = false
+
+# =============================================================================
+# SIGNAL CALLBACKS (set by TileAnimator)
+# =============================================================================
+
+var _on_animation_started: Callable
+var _on_animation_completed: Callable
+var _on_single_tile_animated: Callable
+var _create_tween: Callable
+var _get_tree: Callable
+
+
+func setup(
+	on_started: Callable,
+	on_completed: Callable,
+	on_single: Callable,
+	create_tween: Callable,
+	get_tree: Callable
+) -> void:
+	_on_animation_started = on_started
+	_on_animation_completed = on_completed
+	_on_single_tile_animated = on_single
+	_create_tween = create_tween
+	_get_tree = get_tree
+
+
+# =============================================================================
+# SIGNAL EMISSION
+# =============================================================================
+
+func emit_animation_started(tiles: Array[Tile]) -> void:
+	if _on_animation_started.is_valid():
+		_on_animation_started.call(tiles)
+
+
+func emit_animation_completed(tiles: Array[Tile]) -> void:
+	if _on_animation_completed.is_valid():
+		_on_animation_completed.call(tiles)
+
+
+func emit_single_tile_animated(tile: Tile) -> void:
+	if _on_single_tile_animated.is_valid():
+		_on_single_tile_animated.call(tile)
+
+
+# =============================================================================
+# UTILITIES
+# =============================================================================
+
+func create_tween() -> Tween:
+	if _create_tween.is_valid():
+		return _create_tween.call()
+	return null
+
+
+func get_tree() -> SceneTree:
+	if _get_tree.is_valid():
+		return _get_tree.call()
+	return null
+
+
+func cancel_tile_animation(tile: Tile) -> void:
+	if active_tweens.has(tile):
+		var tween: Tween = active_tweens[tile]
+		if is_instance_valid(tween):
+			tween.kill()
+		active_tweens.erase(tile)
+
+		if active_tweens.is_empty():
+			is_animating = false

--- a/scripts/animation/executors/animation_context.gd.uid
+++ b/scripts/animation/executors/animation_context.gd.uid
@@ -1,0 +1,1 @@
+uid://cvwiyb4g2ocv1

--- a/scripts/animation/executors/animation_executor.gd
+++ b/scripts/animation/executors/animation_executor.gd
@@ -1,0 +1,69 @@
+extends RefCounted
+class_name AnimationExecutor
+
+## Base class for animation executors.
+## Executors encapsulate the logic for executing specific animation types.
+## They share state with the parent TileAnimator via the context.
+
+# =============================================================================
+# CONTEXT (shared state with TileAnimator)
+# =============================================================================
+
+var _context: AnimationContext = null
+
+
+func _init(context: AnimationContext) -> void:
+	_context = context
+
+
+# =============================================================================
+# PROTECTED HELPERS
+# =============================================================================
+
+## Applies a dictionary of properties to a tile.
+func _apply_properties(tile: Tile, properties: Dictionary) -> void:
+	for prop_name in properties.keys():
+		tile.set(prop_name, properties[prop_name])
+
+
+## Registers a tween for a tile in the shared context.
+func _register_tween(tile: Tile, tween: Tween) -> void:
+	_context.active_tweens[tile] = tween
+
+
+## Unregisters a tween for a tile.
+func _unregister_tween(tile: Tile) -> void:
+	_context.active_tweens.erase(tile)
+
+
+## Creates a completion callback for batch animations.
+func _create_batch_completion_callback(
+	tile: Tile,
+	tiles: Array[Tile],
+	strategy: TileAnimationStrategy,
+	completed_count_ref: Array,  # Using array as reference wrapper
+	total_tiles: int
+) -> Callable:
+	return func():
+		strategy.on_animation_complete(tile)
+		_context.emit_single_tile_animated(tile)
+		_unregister_tween(tile)
+		completed_count_ref[0] += 1
+
+		if completed_count_ref[0] >= total_tiles:
+			_context.is_animating = _context.active_tweens.size() > 0
+			_context.emit_animation_completed(tiles)
+
+
+## Creates a completion callback for single tile animations.
+func _create_single_completion_callback(
+	tile: Tile,
+	strategy: TileAnimationStrategy
+) -> Callable:
+	var tiles_array: Array[Tile] = [tile]
+	return func():
+		strategy.on_animation_complete(tile)
+		_context.emit_single_tile_animated(tile)
+		_unregister_tween(tile)
+		_context.is_animating = _context.active_tweens.size() > 0
+		_context.emit_animation_completed(tiles_array)

--- a/scripts/animation/executors/animation_executor.gd.uid
+++ b/scripts/animation/executors/animation_executor.gd.uid
@@ -1,0 +1,1 @@
+uid://chdt6aoh6vje5

--- a/scripts/animation/executors/batch_animation_executor.gd
+++ b/scripts/animation/executors/batch_animation_executor.gd
@@ -1,0 +1,61 @@
+extends AnimationExecutor
+class_name BatchAnimationExecutor
+
+## Executes batch animations with staggered timing.
+## Used for draw animations and other batch property tweens.
+
+
+## Animates a batch of tiles using the provided strategy.
+func execute(tiles: Array[Tile], strategy: TileAnimationStrategy) -> void:
+	_context.is_animating = true
+	_context.emit_animation_started(tiles)
+
+	# Wait for layout to calculate final positions
+	await _context.get_tree().process_frame
+
+	var completed_count_ref: Array = [0]  # Reference wrapper
+	var total_tiles: int = tiles.size()
+
+	for i in tiles.size():
+		var tile: Tile = tiles[i]
+		var delay: float = i * strategy.stagger_delay
+
+		# Capture final position after layout
+		var final_position: Vector2 = tile.position
+
+		# Set starting state
+		var start_offset: Vector2 = strategy.get_start_position_offset()
+		var start_props: Dictionary = strategy.get_start_properties()
+
+		tile.position = final_position + start_offset
+		_apply_properties(tile, start_props)
+
+		# Notify strategy of animation start
+		strategy.on_animation_start(tile)
+
+		# Create staggered animation
+		var tween: Tween = _context.create_tween()
+		tween.set_parallel(true)
+
+		# Position animation
+		tween.tween_property(tile, "position", final_position, strategy.duration) \
+			.set_ease(strategy.ease_type) \
+			.set_trans(strategy.trans_type) \
+			.set_delay(delay)
+
+		# Property animations
+		var end_props: Dictionary = strategy.get_end_properties()
+		for prop_name in end_props.keys():
+			tween.tween_property(tile, prop_name, end_props[prop_name], strategy.duration) \
+				.set_ease(strategy.ease_type) \
+				.set_trans(strategy.trans_type) \
+				.set_delay(delay)
+
+		_register_tween(tile, tween)
+
+		# Track completion
+		tween.finished.connect(
+			_create_batch_completion_callback(tile, tiles, strategy, completed_count_ref, total_tiles)
+		)
+
+	print("[BatchAnimationExecutor] Started animation for %d tiles" % tiles.size())

--- a/scripts/animation/executors/batch_animation_executor.gd.uid
+++ b/scripts/animation/executors/batch_animation_executor.gd.uid
@@ -1,0 +1,1 @@
+uid://dlm3klgps2rsu

--- a/scripts/animation/executors/return_animation_executor.gd
+++ b/scripts/animation/executors/return_animation_executor.gd
@@ -1,0 +1,147 @@
+extends AnimationExecutor
+class_name ReturnAnimationExecutor
+
+## Executes return-to-hand animations.
+## Handles both single tile returns from board and batch cancel animations.
+
+
+## Animates a single tile returning from board to hand.
+func execute_single(tile: Tile, hand: Node, cell: Node, strategy: TileAnimationStrategy) -> void:
+	_context.is_animating = true
+	var tiles_array: Array[Tile] = [tile]
+	_context.emit_animation_started(tiles_array)
+
+	# Capture the tile's current global position (on the board)
+	var start_global_pos: Vector2 = tile.global_position
+
+	# Apply start properties and notify strategy
+	var start_props: Dictionary = strategy.get_start_properties()
+	_apply_properties(tile, start_props)
+	strategy.on_animation_start(tile)
+
+	# Clear the cell's tile reference
+	if cell:
+		cell.tile = null
+
+	# Remove tile from its current parent
+	var current_parent: Node = tile.get_parent()
+	if current_parent:
+		current_parent.remove_child(tile)
+
+	# Add to hand (triggers layout)
+	hand.add_tile(tile)
+
+	# Update tile state
+	tile.current_cell = null
+	tile.location = Tile.TileLocation.IN_HAND
+
+	# Wait for layout
+	await _context.get_tree().process_frame
+
+	# Animate from old position to new
+	_animate_position_transition(tile, start_global_pos, strategy)
+
+	print("[ReturnAnimationExecutor] Started return animation for: %s" % tile.name)
+
+
+## Animates a batch of tiles returning to hand from a cancelled drag.
+func execute_cancel_batch(tiles: Array[Tile], hand: Node, strategy: TileAnimationStrategy) -> void:
+	_context.is_animating = true
+	_context.emit_animation_started(tiles)
+
+	# Step 1: Capture all tiles' current global positions
+	var start_positions: Dictionary = {}
+	for tile in tiles:
+		if is_instance_valid(tile):
+			start_positions[tile] = tile.global_position
+
+	# Step 2: Restore tiles to hand via DragManager
+	DragManager.restore_tiles_to_parents()
+
+	# Step 3: Wait for layout
+	await _context.get_tree().process_frame
+
+	# Step 4: Animate each tile
+	var total_tiles: int = tiles.size()
+	var completed_count_ref: Array = [0]
+
+	for i in tiles.size():
+		var tile: Tile = tiles[i]
+		if not is_instance_valid(tile):
+			completed_count_ref[0] += 1
+			continue
+
+		var start_global_pos: Vector2 = start_positions.get(tile, tile.global_position)
+		var delay: float = i * strategy.stagger_delay
+
+		_animate_position_transition_with_delay(tile, start_global_pos, strategy, delay, tiles, completed_count_ref, total_tiles)
+
+	print("[ReturnAnimationExecutor] Started cancel animation for %d tiles" % tiles.size())
+
+
+## Animates a tile from its old global position to its new position.
+func _animate_position_transition(tile: Tile, start_global_pos: Vector2, strategy: TileAnimationStrategy) -> void:
+	var final_position: Vector2 = tile.position
+	var final_global_pos: Vector2 = tile.global_position
+
+	# Calculate starting local position
+	var global_offset: Vector2 = start_global_pos - final_global_pos
+	tile.position = final_position + global_offset
+
+	# Create animation
+	var tween: Tween = _context.create_tween()
+	tween.set_parallel(true)
+
+	tween.tween_property(tile, "position", final_position, strategy.duration) \
+		.set_ease(strategy.ease_type) \
+		.set_trans(strategy.trans_type)
+
+	var end_props: Dictionary = strategy.get_end_properties()
+	for prop_name in end_props.keys():
+		tween.tween_property(tile, prop_name, end_props[prop_name], strategy.duration) \
+			.set_ease(strategy.ease_type) \
+			.set_trans(strategy.trans_type)
+
+	_register_tween(tile, tween)
+	tween.finished.connect(_create_single_completion_callback(tile, strategy))
+
+
+## Animates with delay for batch operations.
+func _animate_position_transition_with_delay(
+	tile: Tile,
+	start_global_pos: Vector2,
+	strategy: TileAnimationStrategy,
+	delay: float,
+	tiles: Array[Tile],
+	completed_count_ref: Array,
+	total_tiles: int
+) -> void:
+	var final_position: Vector2 = tile.position
+	var final_global_pos: Vector2 = tile.global_position
+
+	var global_offset: Vector2 = start_global_pos - final_global_pos
+	tile.position = final_position + global_offset
+
+	var start_props: Dictionary = strategy.get_start_properties()
+	_apply_properties(tile, start_props)
+	strategy.on_animation_start(tile)
+
+	var tween: Tween = _context.create_tween()
+	tween.set_parallel(true)
+
+	tween.tween_property(tile, "position", final_position, strategy.duration) \
+		.set_ease(strategy.ease_type) \
+		.set_trans(strategy.trans_type) \
+		.set_delay(delay)
+
+	var end_props: Dictionary = strategy.get_end_properties()
+	for prop_name in end_props.keys():
+		tween.tween_property(tile, prop_name, end_props[prop_name], strategy.duration) \
+			.set_ease(strategy.ease_type) \
+			.set_trans(strategy.trans_type) \
+			.set_delay(delay)
+
+	_register_tween(tile, tween)
+	tween.finished.connect(
+		_create_batch_completion_callback(tile, tiles, strategy, completed_count_ref, total_tiles)
+	)

--- a/scripts/animation/executors/return_animation_executor.gd.uid
+++ b/scripts/animation/executors/return_animation_executor.gd.uid
@@ -1,0 +1,1 @@
+uid://djq53xgk0c2cl

--- a/scripts/animation/executors/shake_animation_executor.gd
+++ b/scripts/animation/executors/shake_animation_executor.gd
@@ -1,0 +1,45 @@
+extends AnimationExecutor
+class_name ShakeAnimationExecutor
+
+## Executes shake animations for illegal action feedback.
+## Tiles shake left-right and return to original position.
+
+
+## Animates a shake effect on a single tile.
+func execute(tile: Tile, strategy: ShakeTileAnimation) -> void:
+	# Cancel any existing animation on this tile
+	_context.cancel_tile_animation(tile)
+
+	_context.is_animating = true
+	var tiles_array: Array[Tile] = [tile]
+	_context.emit_animation_started(tiles_array)
+
+	# Store original position
+	var original_position: Vector2 = tile.position
+
+	# Notify strategy
+	strategy.on_animation_start(tile)
+
+	# Create sequential shake animation
+	var tween: Tween = _context.create_tween()
+
+	# Shake left-right multiple times
+	for i in strategy.shake_count:
+		# Move right
+		tween.tween_property(tile, "position:x", original_position.x + strategy.shake_distance, strategy.duration) \
+			.set_ease(strategy.ease_type) \
+			.set_trans(strategy.trans_type)
+		# Move left
+		tween.tween_property(tile, "position:x", original_position.x - strategy.shake_distance, strategy.duration) \
+			.set_ease(strategy.ease_type) \
+			.set_trans(strategy.trans_type)
+
+	# Return to original position
+	tween.tween_property(tile, "position:x", original_position.x, strategy.duration) \
+		.set_ease(strategy.ease_type) \
+		.set_trans(strategy.trans_type)
+
+	_register_tween(tile, tween)
+	tween.finished.connect(_create_single_completion_callback(tile, strategy))
+
+	print("[ShakeAnimationExecutor] Started shake for: %s" % tile.name)

--- a/scripts/animation/executors/shake_animation_executor.gd.uid
+++ b/scripts/animation/executors/shake_animation_executor.gd.uid
@@ -1,0 +1,1 @@
+uid://0mfb03arivra

--- a/scripts/animation/executors/stomp_animation_executor.gd
+++ b/scripts/animation/executors/stomp_animation_executor.gd
@@ -1,0 +1,163 @@
+extends AnimationExecutor
+class_name StompAnimationExecutor
+
+## Executes stomp animations for tile placement confirmation.
+## Tiles rise up, slam down with squish effect, and spawn impact particles.
+
+
+## Animates a batch of tiles with a stomp effect.
+func execute(tiles: Array[Tile], strategy: StompTileAnimation) -> void:
+	_context.is_animating = true
+	_context.emit_animation_started(tiles)
+
+	var completed_count_ref: Array = [0]
+	var total_tiles: int = tiles.size()
+
+	for i in tiles.size():
+		var tile: Tile = tiles[i]
+		var delay: float = i * strategy.stagger_delay
+		var original_position: Vector2 = tile.position
+
+		strategy.on_animation_start(tile)
+
+		var tween: Tween = _context.create_tween()
+
+		# Delay before starting
+		if delay > 0:
+			tween.tween_interval(delay)
+
+		# Phase 1: Rise up (scale up + move up)
+		tween.set_parallel(true)
+		tween.tween_property(tile, "scale", strategy.rise_scale, strategy.rise_duration) \
+			.set_ease(Tween.EASE_OUT) \
+			.set_trans(Tween.TRANS_BACK)
+		tween.tween_property(tile, "position:y", original_position.y + strategy.rise_offset, strategy.rise_duration) \
+			.set_ease(Tween.EASE_OUT) \
+			.set_trans(Tween.TRANS_QUAD)
+
+		# Phase 2: Slam down (scale down + move down fast)
+		tween.set_parallel(false)
+		tween.tween_property(tile, "scale", strategy.squish_scale, strategy.slam_duration) \
+			.set_ease(Tween.EASE_IN) \
+			.set_trans(Tween.TRANS_QUAD)
+		tween.parallel().tween_property(tile, "position:y", original_position.y, strategy.slam_duration) \
+			.set_ease(Tween.EASE_IN) \
+			.set_trans(Tween.TRANS_QUAD)
+
+		# Spawn particles on impact
+		tween.tween_callback(func(): _spawn_impact_particles(tile, strategy))
+
+		# Phase 3: Recover (bounce back to normal)
+		tween.tween_property(tile, "scale", Vector2.ONE, strategy.recover_duration) \
+			.set_ease(Tween.EASE_OUT) \
+			.set_trans(Tween.TRANS_ELASTIC)
+
+		_register_tween(tile, tween)
+		tween.finished.connect(
+			_create_batch_completion_callback(tile, tiles, strategy, completed_count_ref, total_tiles)
+		)
+
+	print("[StompAnimationExecutor] Started stomp for %d tiles" % tiles.size())
+
+
+## Spawns impact particles around a tile's edges when it slams down.
+func _spawn_impact_particles(tile: Tile, strategy: StompTileAnimation) -> void:
+	var tile_size: Vector2 = tile.size if tile.size != Vector2.ZERO else Vector2(64, 64)
+
+	# Spawn particles at each edge (bottom, left, right)
+	var edge_configs: Array = [
+		# [position, direction, spread]
+		[Vector2(tile_size.x / 2, tile_size.y), Vector2(0, 1), 60.0],      # Bottom center
+		[Vector2(0, tile_size.y), Vector2(-1, 0.5), 45.0],                 # Bottom-left corner
+		[Vector2(tile_size.x, tile_size.y), Vector2(1, 0.5), 45.0],        # Bottom-right corner
+		[Vector2(0, tile_size.y / 2), Vector2(-1, 0), 30.0],               # Left edge
+		[Vector2(tile_size.x, tile_size.y / 2), Vector2(1, 0), 30.0],      # Right edge
+	]
+
+	# Distribute particles evenly across edges
+	var particles_distribution: Array[int] = _distribute_particles(strategy.particle_count, edge_configs.size())
+
+	for i in edge_configs.size():
+		var config: Array = edge_configs[i]
+		var pos: Vector2 = config[0]
+		var dir: Vector2 = config[1]
+		var spread: float = config[2]
+		var particle_count: int = particles_distribution[i]
+
+		if particle_count <= 0:
+			continue
+
+		var particles: CPUParticles2D = _create_particle_emitter(particle_count, dir, spread, strategy)
+		particles.position = pos
+		tile.add_child(particles)
+
+		_schedule_particle_cleanup(particles, strategy.particle_lifetime)
+
+
+## Creates a configured CPUParticles2D emitter.
+func _create_particle_emitter(count: int, direction: Vector2, spread: float, strategy: StompTileAnimation) -> CPUParticles2D:
+	var particles: CPUParticles2D = CPUParticles2D.new()
+
+	# Basic settings
+	particles.emitting = true
+	particles.one_shot = true
+	particles.explosiveness = 0.9
+	particles.amount = count
+	particles.lifetime = strategy.particle_lifetime
+
+	# Movement
+	particles.direction = direction
+	particles.spread = spread
+	particles.initial_velocity_min = strategy.particle_speed * 0.6
+	particles.initial_velocity_max = strategy.particle_speed
+	particles.gravity = Vector2(0, 150)
+
+	# Appearance
+	particles.scale_amount_min = strategy.particle_size_min
+	particles.scale_amount_max = strategy.particle_size_max
+
+	# Color with fade out
+	var gradient: Gradient = Gradient.new()
+	gradient.add_point(0.0, strategy.particle_color)
+	gradient.add_point(0.3, strategy.particle_color)
+	gradient.add_point(1.0, Color(strategy.particle_color.r, strategy.particle_color.g, strategy.particle_color.b, 0.0))
+	particles.color_ramp = gradient
+
+	# Size curve - start big, shrink
+	var scale_curve: Curve = Curve.new()
+	scale_curve.add_point(Vector2(0.0, 1.0))
+	scale_curve.add_point(Vector2(0.5, 0.7))
+	scale_curve.add_point(Vector2(1.0, 0.2))
+	particles.scale_amount_curve = scale_curve
+
+	return particles
+
+
+## Schedules particle cleanup using WeakRef for safe handling.
+func _schedule_particle_cleanup(particles: CPUParticles2D, lifetime: float) -> void:
+	var particles_ref: WeakRef = weakref(particles)
+	var tree: SceneTree = _context.get_tree()
+	if tree == null:
+		return
+
+	tree.create_timer(lifetime + 0.2).timeout.connect(func():
+		var p: Node = particles_ref.get_ref()
+		if p != null and is_instance_valid(p):
+			p.queue_free()
+	)
+
+
+## Distributes a total count evenly across a number of buckets.
+func _distribute_particles(total: int, bucket_count: int) -> Array[int]:
+	if bucket_count <= 0:
+		return []
+
+	var result: Array[int] = []
+	var base_count: int = total / bucket_count
+	var remainder: int = total % bucket_count
+
+	for i in bucket_count:
+		var count: int = base_count + (1 if i < remainder else 0)
+		result.append(maxi(count, 1))
+
+	return result

--- a/scripts/animation/executors/stomp_animation_executor.gd.uid
+++ b/scripts/animation/executors/stomp_animation_executor.gd.uid
@@ -1,0 +1,1 @@
+uid://btmxp27mlebx7

--- a/scripts/controllers/AGENT.md
+++ b/scripts/controllers/AGENT.md
@@ -1,0 +1,115 @@
+# Controllers
+
+## Overview
+Controllers encapsulate specific game behaviors that can be activated/deactivated based on game state. They follow the composition pattern to keep scene scripts simple.
+
+## Files
+- `gameplay_controller.gd` - All tile-based gameplay interaction
+
+---
+
+## GameplayController
+
+### Purpose
+Manages all tile-based gameplay interaction including:
+- Tile selection and multi-select
+- Drag and drop (single and multi-tile)
+- Tile placement on board
+- Discard pile interaction
+- Play/submit action
+
+### Lifecycle
+```gdscript
+# Created and added as child of Main
+var controller = GameplayController.new()
+add_child(controller)
+
+# Inject scene dependencies
+controller.setup(board, hand, discard_pile, discard_dialog, main_hud)
+
+# Activate when gameplay should be enabled
+controller.activate()
+
+# Deactivate for menus, dialogs, transitions
+controller.deactivate()
+```
+
+### Signals
+| Signal | Parameters | Description |
+|--------|------------|-------------|
+| `tile_placement_completed` | `tile, cell` | Tile placed on board |
+| `tile_returned_to_hand` | `tile` | Tile returned from board |
+| `play_completed` | `tiles, words` | Tiles played (locked) |
+
+### Key Methods
+```gdscript
+# Setup and lifecycle
+setup(board, hand, discard_pile, discard_dialog, hud) -> void
+activate() -> void
+deactivate() -> void
+
+# Tile registration (called by HandManager via Main)
+register_tile(tile: Tile) -> void
+```
+
+### State
+```gdscript
+enum InteractionMode { IDLE, TILE_SELECTED, DRAGGING }
+
+var interaction_mode: InteractionMode
+var selected_tile: Tile
+var _is_active: bool
+```
+
+### Usage in Main.gd
+```gdscript
+func _ready():
+    _gameplay_controller = GameplayController.new()
+    add_child(_gameplay_controller)
+    _gameplay_controller.setup(board, hand, discard_pile, discard_dialog, main_hud)
+    _gameplay_controller.activate()
+
+func pause_gameplay():
+    _gameplay_controller.deactivate()
+
+func resume_gameplay():
+    _gameplay_controller.activate()
+
+func register_tile(tile: Tile):
+    _gameplay_controller.register_tile(tile)
+```
+
+---
+
+## Design Principles
+
+### Composition Over Inheritance
+Controllers are added as children of the scene they control, not extended. This allows:
+- Easy activation/deactivation
+- Clean separation of concerns
+- Testability in isolation
+
+### Dependency Injection
+Controllers receive their dependencies via `setup()` rather than finding nodes themselves. This:
+- Makes dependencies explicit
+- Allows different configurations
+- Enables testing with mock objects
+
+### Signal-Based Communication
+Controllers emit signals for completed actions rather than directly calling scene methods. This:
+- Decouples controller from specific scene implementation
+- Allows multiple listeners
+- Makes data flow explicit
+
+---
+
+## Future Controllers
+
+As the game grows, additional controllers may be added:
+
+- **MenuController** - Main menu navigation
+- **SettingsController** - Settings UI interaction
+- **TutorialController** - Tutorial flow management
+- **ScoreController** - Score display and animations
+
+Each follows the same pattern: setup, activate, deactivate, signals.

--- a/scripts/controllers/gameplay_controller.gd
+++ b/scripts/controllers/gameplay_controller.gd
@@ -412,25 +412,34 @@ func _return_tile_to_hand_internal(tile: Tile, preserve_selection: bool) -> void
 # =============================================================================
 
 func _handle_single_tile_drop(tile: Tile, cell: BoardCell) -> void:
+	# Check validity BEFORE restoring tiles
+	var is_valid: bool = cell != null and not cell.is_occupied()
+
+	if not is_valid:
+		# Invalid drop - animate tiles back to hand
+		if tile.location == Tile.TileLocation.ON_BOARD:
+			# Board tile - just restore position
+			DragManager.restore_tiles_to_parents()
+			_return_to_original_cell(tile)
+		else:
+			# Hand tile - animate back to hand
+			# Deselect in single-select mode
+			if not SelectionManager.is_multi_select_enabled():
+				SelectionManager.deselect_tile(tile)
+
+			var tiles_to_animate: Array[Tile] = [tile]
+			TileAnimator.animate_cancel_to_hand(tiles_to_animate, hand)
+			_update_interaction_state()
+			_clear_all_cell_hovers()
+
+		if cell != null and cell.is_occupied():
+			print("[Gameplay] Cannot drop on occupied cell: %s" % cell.name)
+
+		_last_placement_success = false
+		return
+
+	# Valid drop - restore and place
 	DragManager.restore_tiles_to_parents()
-
-	if cell == null:
-		if tile.location == Tile.TileLocation.ON_BOARD:
-			_return_to_original_cell(tile)
-		else:
-			_cancel_drag_to_hand(tile)
-		_last_placement_success = false
-		return
-
-	if cell.is_occupied():
-		print("[Gameplay] Cannot drop on occupied cell: %s" % cell.name)
-		if tile.location == Tile.TileLocation.ON_BOARD:
-			_return_to_original_cell(tile)
-		else:
-			_cancel_drag_to_hand(tile)
-		_last_placement_success = false
-		return
-
 	print("[Gameplay] Valid drop on cell: %s" % cell.name)
 	_place_tile_on_cell(tile, cell)
 	_last_placement_success = true
@@ -438,7 +447,7 @@ func _handle_single_tile_drop(tile: Tile, cell: BoardCell) -> void:
 
 func _handle_multi_tile_drop(drop_cell: BoardCell, tiles: Array[Tile]) -> void:
 	if drop_cell == null:
-		_cancel_multi_drag_preserve_selection(tiles)
+		_cancel_multi_drag_with_animation(tiles)
 		_last_placement_success = false
 		return
 
@@ -450,10 +459,11 @@ func _handle_multi_tile_drop(drop_cell: BoardCell, tiles: Array[Tile]) -> void:
 	var cells: Array[BoardCell] = _get_sequential_cells_centered(drop_cell, tiles.size(), lead_index)
 	if cells.is_empty():
 		print("[Gameplay] Cannot place %d tiles centered at %s (lead index: %d)" % [tiles.size(), drop_cell.name, lead_index])
-		_cancel_multi_drag_preserve_selection(tiles)
+		_cancel_multi_drag_with_animation(tiles)
 		_last_placement_success = false
 		return
 
+	# Valid drop - restore and place
 	DragManager.restore_tiles_to_parents()
 
 	for i in tiles.size():
@@ -516,22 +526,18 @@ func _get_sequential_cells_centered(drop_cell: BoardCell, count: int, lead_index
 
 
 func _cancel_multi_drag_preserve_selection(_tiles: Array[Tile]) -> void:
+	# Just restore without animation (used for board tile drags)
 	DragManager.restore_tiles_to_parents()
 	_update_interaction_state()
 	print("[Gameplay] Multi-drag cancelled, selection preserved")
 
 
-func _cancel_drag_to_hand(tile: Tile) -> void:
-	tile.location = Tile.TileLocation.IN_HAND
-	tile.current_cell = null
-	tile.modulate = Color.WHITE
-
-	if not SelectionManager.is_multi_select_enabled():
-		SelectionManager.deselect_tile(tile)
-
+func _cancel_multi_drag_with_animation(tiles: Array[Tile]) -> void:
+	# Animate tiles back to hand (this handles restore internally)
+	TileAnimator.animate_cancel_to_hand(tiles, hand)
 	_update_interaction_state()
 	_clear_all_cell_hovers()
-	print("[Gameplay] Cancelled drag for tile: %s" % tile.name)
+	print("[Gameplay] Multi-drag cancelled with animation, selection preserved")
 
 
 func _return_to_original_cell(tile: Tile) -> void:

--- a/scripts/controllers/gameplay_controller.gd
+++ b/scripts/controllers/gameplay_controller.gd
@@ -266,11 +266,8 @@ func _handle_drag_release(tile: Tile) -> void:
 		dragged_tiles.size()
 	])
 
-	if dragged_tiles.size() > 1:
-		_handle_multi_tile_drop(cell, dragged_tiles)
-	else:
-		_handle_single_tile_drop(tile, cell)
-
+	# Unified drop handling for single and multi-tile
+	_handle_tile_drop(cell, dragged_tiles)
 	DragManager.end_drag(_last_placement_success)
 
 
@@ -411,68 +408,101 @@ func _return_tile_to_hand_internal(tile: Tile, preserve_selection: bool) -> void
 # DROP HANDLERS
 # =============================================================================
 
-func _handle_single_tile_drop(tile: Tile, cell: BoardCell) -> void:
-	# Check validity BEFORE restoring tiles
-	var is_valid: bool = cell != null and not cell.is_occupied()
-
-	if not is_valid:
-		# Invalid drop - animate tiles back to hand
-		if tile.location == Tile.TileLocation.ON_BOARD:
-			# Board tile - just restore position
-			DragManager.restore_tiles_to_parents()
-			_return_to_original_cell(tile)
-		else:
-			# Hand tile - animate back to hand
-			# Deselect in single-select mode
-			if not SelectionManager.is_multi_select_enabled():
-				SelectionManager.deselect_tile(tile)
-
-			var tiles_to_animate: Array[Tile] = [tile]
-			TileAnimator.animate_cancel_to_hand(tiles_to_animate, hand)
-			_update_interaction_state()
-			_clear_all_cell_hovers()
-
-		if cell != null and cell.is_occupied():
-			print("[Gameplay] Cannot drop on occupied cell: %s" % cell.name)
-
+## Unified drop handler for single and multi-tile drops.
+## Validates placement, handles cancellation with animation, or places tiles.
+func _handle_tile_drop(drop_cell: BoardCell, tiles: Array[Tile]) -> void:
+	if tiles.is_empty():
 		_last_placement_success = false
 		return
 
-	# Valid drop - restore and place
-	DragManager.restore_tiles_to_parents()
-	print("[Gameplay] Valid drop on cell: %s" % cell.name)
-	_place_tile_on_cell(tile, cell)
+	# Determine if any tiles are from the board (vs hand)
+	var has_board_tiles: bool = _any_tiles_on_board(tiles)
+
+	# Get target cells for placement
+	var target_cells: Array[BoardCell] = _get_target_cells_for_drop(drop_cell, tiles)
+
+	# Check if placement is valid
+	if target_cells.is_empty():
+		_handle_invalid_drop(tiles, has_board_tiles, drop_cell)
+		_last_placement_success = false
+		return
+
+	# Valid drop - restore tiles and place them
+	_execute_valid_drop(tiles, target_cells)
 	_last_placement_success = true
 
 
-func _handle_multi_tile_drop(drop_cell: BoardCell, tiles: Array[Tile]) -> void:
-	if drop_cell == null:
-		_cancel_multi_drag_with_animation(tiles)
-		_last_placement_success = false
-		return
+## Checks if any tiles in the array are currently on the board.
+func _any_tiles_on_board(tiles: Array[Tile]) -> bool:
+	for tile in tiles:
+		if tile.location == Tile.TileLocation.ON_BOARD:
+			return true
+	return false
 
+
+## Gets the target cells for a drop operation.
+## Returns empty array if placement is invalid.
+func _get_target_cells_for_drop(drop_cell: BoardCell, tiles: Array[Tile]) -> Array[BoardCell]:
+	if drop_cell == null:
+		return []
+
+	if tiles.size() == 1:
+		# Single tile - just check if the cell is free
+		if drop_cell.is_occupied():
+			return []
+		return [drop_cell]
+
+	# Multi-tile - get sequential cells centered on lead tile
 	var lead_tile: Tile = DragManager.lead_tile
 	var lead_index: int = tiles.find(lead_tile)
 	if lead_index == -1:
 		lead_index = 0
 
-	var cells: Array[BoardCell] = _get_sequential_cells_centered(drop_cell, tiles.size(), lead_index)
-	if cells.is_empty():
-		print("[Gameplay] Cannot place %d tiles centered at %s (lead index: %d)" % [tiles.size(), drop_cell.name, lead_index])
-		_cancel_multi_drag_with_animation(tiles)
-		_last_placement_success = false
-		return
+	return _get_sequential_cells_centered(drop_cell, tiles.size(), lead_index)
 
-	# Valid drop - restore and place
+
+## Handles an invalid drop by animating tiles back or restoring board tiles.
+func _handle_invalid_drop(tiles: Array[Tile], has_board_tiles: bool, drop_cell: BoardCell) -> void:
+	if drop_cell != null and drop_cell.is_occupied():
+		print("[Gameplay] Cannot drop on occupied cell: %s" % drop_cell.name)
+	elif drop_cell == null:
+		print("[Gameplay] Cannot drop outside board")
+
+	if has_board_tiles:
+		# Board tiles - restore to original positions without animation
+		DragManager.restore_tiles_to_parents()
+		for tile in tiles:
+			if tile.location == Tile.TileLocation.ON_BOARD:
+				_return_to_original_cell(tile)
+	else:
+		# Hand tiles - animate back with smooth transition
+		_animate_tiles_back_to_hand(tiles)
+
+	_update_interaction_state()
+	_clear_all_cell_hovers()
+
+
+## Animates tiles back to hand with proper selection handling.
+func _animate_tiles_back_to_hand(tiles: Array[Tile]) -> void:
+	# In single-select mode with one tile, deselect it
+	if tiles.size() == 1 and not SelectionManager.is_multi_select_enabled():
+		SelectionManager.deselect_tile(tiles[0])
+
+	# Animate all tiles back to hand
+	TileAnimator.animate_cancel_to_hand(tiles, hand)
+	print("[Gameplay] Animating %d tile(s) back to hand" % tiles.size())
+
+
+## Executes a valid drop by restoring and placing tiles.
+func _execute_valid_drop(tiles: Array[Tile], target_cells: Array[BoardCell]) -> void:
 	DragManager.restore_tiles_to_parents()
 
 	for i in tiles.size():
-		_place_tile_on_cell_silent(tiles[i], cells[i])
+		_place_tile_on_cell_silent(tiles[i], target_cells[i])
 
 	SelectionManager.deselect_all()
 	_update_interaction_state()
-	_last_placement_success = true
-	print("[Gameplay] Multi-drop: placed %d tiles centered at %s" % [tiles.size(), drop_cell.name])
+	print("[Gameplay] Placed %d tile(s) on board" % tiles.size())
 
 
 func _handle_drop_on_discard_pile(tiles: Array[Tile]) -> void:
@@ -523,21 +553,6 @@ func _get_sequential_cells_centered(drop_cell: BoardCell, count: int, lead_index
 		cells.append(cell)
 
 	return cells
-
-
-func _cancel_multi_drag_preserve_selection(_tiles: Array[Tile]) -> void:
-	# Just restore without animation (used for board tile drags)
-	DragManager.restore_tiles_to_parents()
-	_update_interaction_state()
-	print("[Gameplay] Multi-drag cancelled, selection preserved")
-
-
-func _cancel_multi_drag_with_animation(tiles: Array[Tile]) -> void:
-	# Animate tiles back to hand (this handles restore internally)
-	TileAnimator.animate_cancel_to_hand(tiles, hand)
-	_update_interaction_state()
-	_clear_all_cell_hovers()
-	print("[Gameplay] Multi-drag cancelled with animation, selection preserved")
 
 
 func _return_to_original_cell(tile: Tile) -> void:

--- a/scripts/controllers/gameplay_controller.gd
+++ b/scripts/controllers/gameplay_controller.gd
@@ -1,0 +1,702 @@
+extends Node
+class_name GameplayController
+
+## GameplayController: Manages all tile-based gameplay interaction.
+## Handles tile selection, drag/drop, placement, discard, and play actions.
+## Can be enabled/disabled based on game state (e.g., disabled during menus).
+
+# =============================================================================
+# SIGNALS
+# =============================================================================
+
+signal tile_placement_completed(tile: Tile, cell: BoardCell)
+signal tile_returned_to_hand(tile: Tile)
+signal play_completed(tiles: Array[Tile], words: Array)
+
+# =============================================================================
+# STATE
+# =============================================================================
+
+enum InteractionMode {
+	IDLE,           # No tile selected, waiting for input
+	TILE_SELECTED,  # Tile selected from hand, waiting for placement
+	DRAGGING        # Tile being dragged
+}
+
+var interaction_mode: InteractionMode = InteractionMode.IDLE
+var selected_tile: Tile = null
+var _last_placement_success: bool = false
+var _is_active: bool = false
+
+# =============================================================================
+# DEPENDENCIES (injected via setup)
+# =============================================================================
+
+var board: Board = null
+var hand: Hand = null
+var discard_pile: Control = null
+var discard_dialog: CanvasLayer = null
+var main_hud: CanvasLayer = null
+
+var _word_validator: WordValidator = null
+
+
+# =============================================================================
+# LIFECYCLE
+# =============================================================================
+
+func _ready() -> void:
+	_word_validator = WordValidator.new()
+
+
+func _unhandled_input(event: InputEvent) -> void:
+	if not _is_active:
+		return
+
+	if event.is_action_pressed("toggle_multi_select"):
+		SelectionManager.toggle_mode()
+
+	if event.is_action_pressed("discard_tiles"):
+		_request_discard_confirmation()
+
+
+## Sets up the controller with required scene references.
+func setup(p_board: Board, p_hand: Hand, p_discard_pile: Control, p_discard_dialog: CanvasLayer, p_hud: CanvasLayer) -> void:
+	board = p_board
+	hand = p_hand
+	discard_pile = p_discard_pile
+	discard_dialog = p_discard_dialog
+	main_hud = p_hud
+
+
+## Activates the controller and connects all signals.
+func activate() -> void:
+	if _is_active:
+		return
+	_is_active = true
+	_connect_signals()
+	print("[GameplayController] Activated")
+
+
+## Deactivates the controller and disconnects all signals.
+func deactivate() -> void:
+	if not _is_active:
+		return
+	_is_active = false
+	_disconnect_signals()
+	SelectionManager.deselect_all()
+	print("[GameplayController] Deactivated")
+
+
+func _connect_signals() -> void:
+	# Board signals
+	if board:
+		board.cell_clicked.connect(_on_cell_clicked)
+		board.cell_hovered.connect(_on_cell_hovered)
+		board.cell_unhovered.connect(_on_cell_unhovered)
+
+	# Discard signals
+	if discard_pile:
+		discard_pile.tiles_dropped.connect(_on_discard_pile_tiles_dropped)
+		discard_pile.peek_requested.connect(_on_discard_pile_peek_requested)
+	if discard_dialog:
+		discard_dialog.confirmed.connect(_on_discard_confirmed)
+		discard_dialog.cancelled.connect(_on_discard_cancelled)
+
+	# HUD signals
+	if main_hud:
+		main_hud.play_requested.connect(_on_play_requested)
+
+	# Drag signals
+	DragManager.drag_release_requested.connect(_handle_drag_release)
+
+
+func _disconnect_signals() -> void:
+	# Board signals
+	if board:
+		if board.cell_clicked.is_connected(_on_cell_clicked):
+			board.cell_clicked.disconnect(_on_cell_clicked)
+		if board.cell_hovered.is_connected(_on_cell_hovered):
+			board.cell_hovered.disconnect(_on_cell_hovered)
+		if board.cell_unhovered.is_connected(_on_cell_unhovered):
+			board.cell_unhovered.disconnect(_on_cell_unhovered)
+
+	# Discard signals
+	if discard_pile and discard_pile.tiles_dropped.is_connected(_on_discard_pile_tiles_dropped):
+		discard_pile.tiles_dropped.disconnect(_on_discard_pile_tiles_dropped)
+	if discard_pile and discard_pile.peek_requested.is_connected(_on_discard_pile_peek_requested):
+		discard_pile.peek_requested.disconnect(_on_discard_pile_peek_requested)
+	if discard_dialog and discard_dialog.confirmed.is_connected(_on_discard_confirmed):
+		discard_dialog.confirmed.disconnect(_on_discard_confirmed)
+	if discard_dialog and discard_dialog.cancelled.is_connected(_on_discard_cancelled):
+		discard_dialog.cancelled.disconnect(_on_discard_cancelled)
+
+	# HUD signals
+	if main_hud and main_hud.play_requested.is_connected(_on_play_requested):
+		main_hud.play_requested.disconnect(_on_play_requested)
+
+	# Drag signals
+	if DragManager.drag_release_requested.is_connected(_handle_drag_release):
+		DragManager.drag_release_requested.disconnect(_handle_drag_release)
+
+
+# =============================================================================
+# PUBLIC API - Called by Main or HandManager when tiles are created
+# =============================================================================
+
+## Connects tile signals to this controller. Call when a tile is created.
+func register_tile(tile: Tile) -> void:
+	if not tile.tile_selected.is_connected(_on_tile_selected):
+		tile.tile_selected.connect(_on_tile_selected)
+	if not tile.tile_right_clicked.is_connected(_on_tile_right_clicked):
+		tile.tile_right_clicked.connect(_on_tile_right_clicked)
+	if not tile.tile_drag_started.is_connected(_on_tile_drag_started):
+		tile.tile_drag_started.connect(_on_tile_drag_started)
+	if not tile.tile_drag_ended.is_connected(_on_tile_drag_ended):
+		tile.tile_drag_ended.connect(_on_tile_drag_ended)
+
+
+# =============================================================================
+# TILE SELECTION HANDLERS
+# =============================================================================
+
+func _on_tile_selected(tile: Tile) -> void:
+	if not _is_active:
+		return
+
+	print("[Gameplay] Tile selected: %s" % tile.name)
+
+	# Clicking a board tile while we have selection
+	if SelectionManager.has_selection() and tile.location == Tile.TileLocation.ON_BOARD:
+		print("[Gameplay] Cannot stack tiles")
+		return
+
+	# Clicking a tile that's already on the board (info only)
+	if not SelectionManager.has_selection() and tile.location == Tile.TileLocation.ON_BOARD:
+		print("[Gameplay] Board tile at cell: %s" % tile.current_cell.name)
+		return
+
+	# Hand tile - use SelectionManager
+	if tile.location == Tile.TileLocation.IN_HAND:
+		SelectionManager.select_tile(tile)
+		_update_interaction_state()
+
+
+func _on_tile_right_clicked(tile: Tile) -> void:
+	if not _is_active:
+		return
+
+	if SelectionManager.has_selection():
+		print("[Gameplay] Cannot remove tile while selection active")
+		return
+
+	if tile.current_cell == null:
+		print("[Gameplay] Tile is not on board")
+		return
+
+	if tile.is_locked:
+		print("[Gameplay] Cannot return tile - tile is locked (already played)")
+		TileAnimator.animate_shake(tile)
+		return
+
+	if hand.is_full():
+		print("[Gameplay] Cannot return tile - hand is full")
+		TileAnimator.animate_shake(tile)
+		return
+
+	_return_tile_to_hand(tile)
+
+
+func _on_tile_drag_started(tile: Tile) -> void:
+	if not _is_active:
+		return
+
+	if tile.is_locked:
+		print("[Gameplay] Cannot drag locked tile: %s" % tile.name)
+		return
+
+	var tiles_to_drag: Array[Tile] = SelectionManager.get_selected_tiles()
+
+	if tile not in tiles_to_drag:
+		SelectionManager.deselect_all()
+		SelectionManager.select_tile(tile)
+		tiles_to_drag = [tile]
+
+	for t in tiles_to_drag:
+		if t != tile:
+			t.set_as_drag_follower()
+
+	DragManager.start_drag(tile, tiles_to_drag)
+
+	if tiles_to_drag.size() > 1:
+		print("[Gameplay] Multi-drag started with %d tiles" % tiles_to_drag.size())
+
+
+func _on_tile_drag_ended(tile: Tile) -> void:
+	if not _is_active:
+		return
+	if not DragManager.is_dragging:
+		return
+	if tile != DragManager.lead_tile:
+		return
+	_handle_drag_release(tile)
+
+
+func _handle_drag_release(tile: Tile) -> void:
+	if not _is_active:
+		return
+	if not DragManager.is_dragging:
+		return
+
+	var dragged_tiles: Array[Tile] = DragManager.get_dragged_tiles()
+	var mouse_pos: Vector2 = get_viewport().get_mouse_position()
+
+	if discard_pile and discard_pile.is_drop_target(mouse_pos):
+		_handle_drop_on_discard_pile(dragged_tiles)
+		DragManager.end_drag(false)
+		return
+
+	var cell: BoardCell = _get_cell_under_mouse()
+
+	var cell_name: String = String(cell.name) if cell else "none"
+	print("[Gameplay] Drag ended - Tile: %s | Location: %s | Cell: %s | Multi: %d" % [
+		tile.name,
+		Tile.TileLocation.keys()[tile.location],
+		cell_name,
+		dragged_tiles.size()
+	])
+
+	if dragged_tiles.size() > 1:
+		_handle_multi_tile_drop(cell, dragged_tiles)
+	else:
+		_handle_single_tile_drop(tile, cell)
+
+	DragManager.end_drag(_last_placement_success)
+
+
+# =============================================================================
+# CELL HANDLERS
+# =============================================================================
+
+func _on_cell_clicked(cell: BoardCell) -> void:
+	if not _is_active:
+		return
+
+	var selected_tiles: Array[Tile] = SelectionManager.get_selected_tiles()
+
+	if selected_tiles.is_empty():
+		print("[Gameplay] No tile selected")
+		return
+
+	if cell.is_occupied():
+		print("[Gameplay] Cell occupied: %s" % cell.name)
+		return
+
+	if selected_tiles.size() > 1:
+		var cells: Array[BoardCell] = _get_sequential_cells(cell, selected_tiles.size())
+		if cells.is_empty():
+			print("[Gameplay] Cannot place %d tiles starting at %s" % [selected_tiles.size(), cell.name])
+			return
+
+		for i in selected_tiles.size():
+			_place_tile_on_cell_silent(selected_tiles[i], cells[i])
+
+		SelectionManager.deselect_all()
+		_update_interaction_state()
+		print("[Gameplay] Placed %d tiles starting at %s" % [selected_tiles.size(), cell.name])
+	else:
+		_place_tile_on_cell(selected_tiles[0], cell)
+
+
+func _on_cell_hovered(cell: BoardCell) -> void:
+	if not _is_active:
+		return
+	if not SelectionManager.has_selection():
+		return
+
+	var selected_count: int = SelectionManager.get_selection_count()
+
+	if selected_count > 1:
+		var cells: Array[BoardCell] = _get_sequential_cells(cell, selected_count)
+		if cells.is_empty():
+			cell.show_invalid_hover()
+		else:
+			for c in cells:
+				c.show_valid_hover()
+	else:
+		if cell.is_occupied():
+			cell.show_invalid_hover()
+		else:
+			cell.show_valid_hover()
+
+
+func _on_cell_unhovered(cell: BoardCell) -> void:
+	if not _is_active:
+		return
+	cell.clear_hover()
+
+
+# =============================================================================
+# TILE PLACEMENT
+# =============================================================================
+
+func _place_tile_on_cell(tile: Tile, cell: BoardCell) -> void:
+	if cell.is_occupied():
+		return
+
+	_place_tile_on_cell_silent(tile, cell)
+	SelectionManager.deselect_tile(tile)
+	_update_interaction_state()
+
+
+func _place_tile_on_cell_silent(tile: Tile, cell: BoardCell) -> void:
+	if cell.is_occupied():
+		return
+
+	if tile.location == Tile.TileLocation.ON_BOARD and tile.current_cell != null:
+		var old_cell: BoardCell = tile.current_cell
+		old_cell.tile = null
+		print("[Gameplay] Cleared old cell: %s" % old_cell.name)
+
+	tile.get_parent().remove_child(tile)
+	cell.tile_anchor.add_child(tile)
+	tile.position = Vector2.ZERO
+
+	tile.current_cell = cell
+	tile.location = Tile.TileLocation.ON_BOARD
+	cell.tile = tile
+
+	_clear_all_cell_hovers()
+
+	EventBus.tile_placed.emit(tile, cell)
+	tile_placement_completed.emit(tile, cell)
+	_update_play_button_state()
+	print("[Gameplay] Placed tile %s on cell %s" % [tile.name, cell.name])
+
+
+func _return_tile_to_hand(tile: Tile) -> void:
+	_return_tile_to_hand_internal(tile, false)
+
+
+func _return_tile_to_hand_internal(tile: Tile, preserve_selection: bool) -> void:
+	if tile.current_cell == null and tile.location != Tile.TileLocation.IN_HAND:
+		if tile.get_parent():
+			tile.get_parent().remove_child(tile)
+		hand.add_tile(tile)
+		tile.location = Tile.TileLocation.IN_HAND
+		tile.modulate = Color.WHITE
+		if not preserve_selection:
+			SelectionManager.deselect_tile(tile)
+		return
+
+	if tile.current_cell == null:
+		return
+
+	var cell: BoardCell = tile.current_cell
+	TileAnimator.animate_return_to_hand(tile, hand, cell)
+
+	if not preserve_selection:
+		SelectionManager.deselect_tile(tile)
+
+	_update_interaction_state()
+	_clear_all_cell_hovers()
+
+	EventBus.tile_removed.emit(tile, cell)
+	tile_returned_to_hand.emit(tile)
+	_update_play_button_state()
+	print("[Gameplay] Returned tile %s from cell %s to hand (animated)" % [tile.name, cell.name])
+
+
+# =============================================================================
+# DROP HANDLERS
+# =============================================================================
+
+func _handle_single_tile_drop(tile: Tile, cell: BoardCell) -> void:
+	DragManager.restore_tiles_to_parents()
+
+	if cell == null:
+		if tile.location == Tile.TileLocation.ON_BOARD:
+			_return_to_original_cell(tile)
+		else:
+			_cancel_drag_to_hand(tile)
+		_last_placement_success = false
+		return
+
+	if cell.is_occupied():
+		print("[Gameplay] Cannot drop on occupied cell: %s" % cell.name)
+		if tile.location == Tile.TileLocation.ON_BOARD:
+			_return_to_original_cell(tile)
+		else:
+			_cancel_drag_to_hand(tile)
+		_last_placement_success = false
+		return
+
+	print("[Gameplay] Valid drop on cell: %s" % cell.name)
+	_place_tile_on_cell(tile, cell)
+	_last_placement_success = true
+
+
+func _handle_multi_tile_drop(drop_cell: BoardCell, tiles: Array[Tile]) -> void:
+	if drop_cell == null:
+		_cancel_multi_drag_preserve_selection(tiles)
+		_last_placement_success = false
+		return
+
+	var lead_tile: Tile = DragManager.lead_tile
+	var lead_index: int = tiles.find(lead_tile)
+	if lead_index == -1:
+		lead_index = 0
+
+	var cells: Array[BoardCell] = _get_sequential_cells_centered(drop_cell, tiles.size(), lead_index)
+	if cells.is_empty():
+		print("[Gameplay] Cannot place %d tiles centered at %s (lead index: %d)" % [tiles.size(), drop_cell.name, lead_index])
+		_cancel_multi_drag_preserve_selection(tiles)
+		_last_placement_success = false
+		return
+
+	DragManager.restore_tiles_to_parents()
+
+	for i in tiles.size():
+		_place_tile_on_cell_silent(tiles[i], cells[i])
+
+	SelectionManager.deselect_all()
+	_update_interaction_state()
+	_last_placement_success = true
+	print("[Gameplay] Multi-drop: placed %d tiles centered at %s" % [tiles.size(), drop_cell.name])
+
+
+func _handle_drop_on_discard_pile(tiles: Array[Tile]) -> void:
+	var hand_tiles: Array[Tile] = []
+	for tile in tiles:
+		if tile.location == Tile.TileLocation.IN_HAND:
+			hand_tiles.append(tile)
+
+	if hand_tiles.is_empty():
+		DragManager.restore_tiles_to_parents()
+		print("[Gameplay] Cannot discard board tiles")
+		return
+
+	DragManager.restore_tiles_to_parents()
+	discard_dialog.show_confirmation(hand_tiles.size())
+	print("[Gameplay] Dropped %d tiles on discard pile, awaiting confirmation" % hand_tiles.size())
+
+
+# =============================================================================
+# CELL HELPERS
+# =============================================================================
+
+func _get_sequential_cells(start: BoardCell, count: int) -> Array[BoardCell]:
+	var cells: Array[BoardCell] = []
+	var pos: Vector2i = start.grid_position
+	var direction: Vector2i = Vector2i.RIGHT
+
+	for i in count:
+		var cell: BoardCell = board.get_cell(pos.y, pos.x)
+		if cell == null or cell.is_occupied():
+			return []
+		cells.append(cell)
+		pos += direction
+	return cells
+
+
+func _get_sequential_cells_centered(drop_cell: BoardCell, count: int, lead_index: int) -> Array[BoardCell]:
+	var cells: Array[BoardCell] = []
+	var drop_pos: Vector2i = drop_cell.grid_position
+	var direction: Vector2i = Vector2i.RIGHT
+	var start_pos: Vector2i = drop_pos - (direction * lead_index)
+
+	for i in count:
+		var pos: Vector2i = start_pos + (direction * i)
+		var cell: BoardCell = board.get_cell(pos.y, pos.x)
+		if cell == null or cell.is_occupied():
+			return []
+		cells.append(cell)
+
+	return cells
+
+
+func _cancel_multi_drag_preserve_selection(_tiles: Array[Tile]) -> void:
+	DragManager.restore_tiles_to_parents()
+	_update_interaction_state()
+	print("[Gameplay] Multi-drag cancelled, selection preserved")
+
+
+func _cancel_drag_to_hand(tile: Tile) -> void:
+	tile.location = Tile.TileLocation.IN_HAND
+	tile.current_cell = null
+	tile.modulate = Color.WHITE
+
+	if not SelectionManager.is_multi_select_enabled():
+		SelectionManager.deselect_tile(tile)
+
+	_update_interaction_state()
+	_clear_all_cell_hovers()
+	print("[Gameplay] Cancelled drag for tile: %s" % tile.name)
+
+
+func _return_to_original_cell(tile: Tile) -> void:
+	if tile.current_cell == null:
+		push_error("[Gameplay] Board tile has no current_cell reference!")
+		return
+
+	tile.position = Vector2.ZERO
+	tile.modulate = Color.WHITE
+	print("[Gameplay] Tile %s returned to cell: %s" % [tile.name, tile.current_cell.name])
+
+
+func _get_cell_under_mouse() -> BoardCell:
+	var mouse_pos: Vector2 = get_viewport().get_mouse_position()
+	return board.get_cell_at_position(mouse_pos)
+
+
+func _clear_all_cell_hovers() -> void:
+	for cell in board.get_all_cells():
+		cell.clear_hover()
+
+
+# =============================================================================
+# DISCARD HANDLERS
+# =============================================================================
+
+func _request_discard_confirmation() -> void:
+	var selected_tiles: Array[Tile] = SelectionManager.get_selected_tiles()
+
+	var hand_tiles: Array[Tile] = []
+	for tile in selected_tiles:
+		if tile.location == Tile.TileLocation.IN_HAND:
+			hand_tiles.append(tile)
+
+	if hand_tiles.is_empty():
+		print("[Gameplay] No hand tiles selected to discard")
+		return
+
+	discard_dialog.show_confirmation(hand_tiles.size())
+	EventBus.discard_confirmation_requested.emit(hand_tiles.size())
+
+
+func _on_discard_confirmed() -> void:
+	var selected_tiles: Array[Tile] = SelectionManager.get_selected_tiles()
+
+	var hand_tiles: Array[Tile] = []
+	for tile in selected_tiles:
+		if tile.location == Tile.TileLocation.IN_HAND:
+			hand_tiles.append(tile)
+
+	if hand_tiles.is_empty():
+		return
+
+	_discard_tiles(hand_tiles)
+	EventBus.discard_confirmed.emit()
+	print("[Gameplay] Discard confirmed: %d tiles" % hand_tiles.size())
+
+
+func _on_discard_cancelled() -> void:
+	EventBus.discard_cancelled.emit()
+	print("[Gameplay] Discard cancelled, selection preserved")
+
+
+func _on_discard_pile_tiles_dropped(tiles: Array) -> void:
+	var hand_tiles: Array[Tile] = []
+	for tile in tiles:
+		if tile is Tile and tile.location == Tile.TileLocation.IN_HAND:
+			hand_tiles.append(tile)
+
+	if hand_tiles.is_empty():
+		return
+
+	discard_dialog.show_confirmation(hand_tiles.size())
+
+
+func _on_discard_pile_peek_requested() -> void:
+	var pile: Array[Tile] = HandManager.get_discard_pile()
+	print("[Gameplay] Peek requested - Discard pile has %d tiles" % pile.size())
+
+
+func _discard_tiles(tiles: Array[Tile]) -> void:
+	SelectionManager.deselect_all()
+
+	for tile in tiles:
+		HandManager.discard_tile(tile)
+
+	var refilled: int = HandManager.refill_hand()
+	print("[Gameplay] Discarded %d tiles, refilled %d" % [tiles.size(), refilled])
+
+	_update_interaction_state()
+
+
+# =============================================================================
+# PLAY HANDLERS
+# =============================================================================
+
+func _on_play_requested() -> void:
+	if not _is_active:
+		return
+
+	print("[Gameplay] Play requested")
+
+	var unplayed_tiles: Array[Tile] = _get_unplayed_board_tiles()
+
+	if unplayed_tiles.is_empty():
+		print("[Gameplay] No tiles to play")
+		return
+
+	var positions: Array[Vector2i] = []
+	for tile in unplayed_tiles:
+		if tile.current_cell:
+			positions.append(tile.current_cell.grid_position)
+
+	var words: Array = _word_validator.find_formed_words(board, positions)
+
+	print("[Gameplay] Found %d words from %d tiles" % [words.size(), unplayed_tiles.size()])
+	for word_info in words:
+		print("[Gameplay] Word: '%s' (%s)" % [word_info.word, word_info.direction])
+
+	for tile in unplayed_tiles:
+		tile.is_locked = true
+		print("[Gameplay] Locked tile: %s" % tile.name)
+
+	TileAnimator.animate_stomp_batch(unplayed_tiles)
+
+	EventBus.tiles_played.emit(unplayed_tiles, words)
+	play_completed.emit(unplayed_tiles, words)
+
+	_update_play_button_state()
+	print("[Gameplay] Played %d tiles, formed %d words" % [unplayed_tiles.size(), words.size()])
+
+
+func _get_unplayed_board_tiles() -> Array[Tile]:
+	var tiles: Array[Tile] = []
+	for cell in board.get_all_cells():
+		if cell.is_occupied() and not cell.tile.is_locked:
+			tiles.append(cell.tile)
+	return tiles
+
+
+func _update_play_button_state() -> void:
+	if main_hud:
+		var has_unplayed_tiles: bool = not _get_unplayed_board_tiles().is_empty()
+		main_hud.set_play_button_enabled(has_unplayed_tiles)
+
+
+# =============================================================================
+# STATE MANAGEMENT
+# =============================================================================
+
+func _update_interaction_state() -> void:
+	var has_selection: bool = SelectionManager.has_selection()
+
+	if has_selection:
+		interaction_mode = InteractionMode.TILE_SELECTED
+		selected_tile = SelectionManager.get_selected_tiles()[0] if SelectionManager.get_selection_count() == 1 else null
+		_set_hand_tiles_hover_enabled(false)
+	else:
+		interaction_mode = InteractionMode.IDLE
+		selected_tile = null
+		_set_hand_tiles_hover_enabled(true)
+		_clear_all_cell_hovers()
+
+
+func _set_hand_tiles_hover_enabled(enabled: bool) -> void:
+	if hand:
+		for tile in hand.get_tiles():
+			tile.allow_hover_feedback = enabled

--- a/scripts/controllers/gameplay_controller.gd.uid
+++ b/scripts/controllers/gameplay_controller.gd.uid
@@ -1,0 +1,1 @@
+uid://b6qwblj5q2ymi


### PR DESCRIPTION
This pull request introduces a new `DragManager` autoload singleton to coordinate multi-tile drag-and-drop operations, significantly improving the architecture for handling complex drag behaviors. The changes modularize drag logic, provide robust state management for multi-tile drags, and add new animation support for cancelled drags. Tile and animation code is updated to integrate with the new manager, and documentation is expanded to describe the new system.

Key changes include:

**Multi-Tile Drag Architecture**

* Added a new `DragManager` singleton (`autoload/drag_manager.gd`) that manages the lifecycle, state, and positioning of multi-tile drag operations, including lead/follower tile roles, original parent/position tracking, and drag container management. It exposes signals and a public API for starting, ending, cancelling, and restoring drags. [[1]](diffhunk://#diff-b0d7046b6e032c5a333b88c9841a6032f408e9db91afac7a721dcb3ae1f7b557R1-R296) [[2]](diffhunk://#diff-edf18b7fc148190271842b4d3f945faadc6234be393c325c3f19b80a1667a6c0R1)
* Updated the autoload documentation (`autoload/AGENT.md`) to describe the purpose, API, and usage of `DragManager`, and included it in the global managers list and load order. [[1]](diffhunk://#diff-15a021991221402284d3245bfed86f04b230b1235ea6f3e756b2ae405fd241c6R13) [[2]](diffhunk://#diff-15a021991221402284d3245bfed86f04b230b1235ea6f3e756b2ae405fd241c6R403-R469) [[3]](diffhunk://#diff-15a021991221402284d3245bfed86f04b230b1235ea6f3e756b2ae405fd241c6R479)
* Registered `DragManager` in the Godot project autoloads (`project.godot`).

**Tile and Animation Integration**

* Refactored tile drag logic in `scenes/tile/tile.gd` to support lead/follower roles, delegate follower positioning to `DragManager`, and add robust drag state reset/cleanup methods for external control. [[1]](diffhunk://#diff-8c0a86ccdead4c405b7accfed47ca03c615d66a4d753c9435d4f8a3e3d1da4e4R62) [[2]](diffhunk://#diff-8c0a86ccdead4c405b7accfed47ca03c615d66a4d753c9435d4f8a3e3d1da4e4L83-R86) [[3]](diffhunk://#diff-8c0a86ccdead4c405b7accfed47ca03c615d66a4d753c9435d4f8a3e3d1da4e4R172-R199) [[4]](diffhunk://#diff-8c0a86ccdead4c405b7accfed47ca03c615d66a4d753c9435d4f8a3e3d1da4e4R248) [[5]](diffhunk://#diff-8c0a86ccdead4c405b7accfed47ca03c615d66a4d753c9435d4f8a3e3d1da4e4R266)
* Added a new animation for cancelled drags in `autoload/tile_animator.gd`, allowing tiles to smoothly return to hand after a drag is cancelled, with batch support and proper tweening. [[1]](diffhunk://#diff-927dd372c3919f564c0e320071da0d46f2b7f366e64a2c06056370e1879b9cc2R92-R104) [[2]](diffhunk://#diff-927dd372c3919f564c0e320071da0d46f2b7f366e64a2c06056370e1879b9cc2R276-R353)

**Hand Manager and Signal Handling**

* Simplified signal connections in `autoload/hand_manager.gd` by registering tiles with the main gameplay controller, preparing for the new drag architecture.