### PR TITLE
Decks

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -3,8 +3,6 @@
     "allow": [
       "Bash(git mv:*)",
       "Bash(grep:*)",
-      "Bash(for file in C:/Users/suporte/Documents/dev/Data/TileData/tiles/tile_[b-z].tres)",
-      "Bash(do sed -i 's/letter = \"\" \\\\\\([A-Z]\\\\\\)\"\"/letter = \"\"\\\\1\"\"/' \"$file\")",
       "Bash(done)",
       "Bash(godot:*)",
       "Bash(while read dir)",
@@ -13,7 +11,10 @@
       "Bash(fi)",
       "Bash(wc:*)",
       "Bash(ls:*)",
-      "Bash(git rm:*)"
+      "Bash(git rm:*)",
+      "Bash(cd:*)",
+      "Bash(cat:*)",
+      "Bash(py:*)"
     ]
   }
 }

--- a/Data/BagDistribution/bag_equal.tres
+++ b/Data/BagDistribution/bag_equal.tres
@@ -1,0 +1,35 @@
+[gd_resource type="Resource" script_class="BagDistribution" load_steps=2 format=3 uid="uid://bag_equal_dist_1"]
+
+[ext_resource type="Script" uid="uid://dmo2awwrmb1jw" path="res://Data/BagDistribution/bag_distribution.gd" id="1_q047y"]
+
+[resource]
+script = ExtResource("1_q047y")
+distribution = {
+"A": 1,
+"B": 1,
+"C": 1,
+"D": 1,
+"E": 1,
+"F": 1,
+"G": 1,
+"H": 1,
+"I": 1,
+"J": 1,
+"K": 1,
+"L": 1,
+"M": 1,
+"N": 1,
+"O": 1,
+"P": 1,
+"Q": 1,
+"R": 1,
+"S": 1,
+"T": 1,
+"U": 1,
+"V": 1,
+"W": 1,
+"X": 1,
+"Y": 1,
+"Z": 1
+}
+metadata/_custom_type_script = "uid://dmo2awwrmb1jw"

--- a/autoload/hand_manager.gd
+++ b/autoload/hand_manager.gd
@@ -22,7 +22,7 @@ signal tile_ready(tile: Tile)
 # =============================================================================
 
 var hand_size: int = 10
-var discard_pile: Array[Tile] = []
+var _discard_pile: Array[Tile] = []
 
 # =============================================================================
 # SCENE REFERENCES (resolved at runtime)
@@ -115,13 +115,13 @@ func discard_tile(tile: Tile) -> bool:
 
 	_hand_ui.remove_tile(tile)
 	tile.move_to_discard()  # Atomic state update
-	discard_pile.append(tile)
+	_discard_pile.append(tile)
 
 	EventBus.tile_discarded.emit(tile)
-	EventBus.discard_count_changed.emit(discard_pile.size())
+	EventBus.discard_count_changed.emit(_discard_pile.size())
 	EventBus.hand_count_changed.emit(_hand_ui.get_tile_count())
 
-	print("[HandManager] Discarded tile: %s | Discard pile: %d" % [tile.letter, discard_pile.size()])
+	print("[HandManager] Discarded tile: %s | Discard pile: %d" % [tile.letter, _discard_pile.size()])
 	return true
 
 
@@ -142,18 +142,18 @@ func discard_selected() -> int:
 
 ## Returns the discard pile contents.
 func get_discard_pile() -> Array[Tile]:
-	return discard_pile.duplicate()
+	return _discard_pile.duplicate()
 
 
 ## Gets the discard pile size.
 func get_discard_count() -> int:
-	return discard_pile.size()
+	return _discard_pile.size()
 
 
 ## Clears the discard pile and returns its contents. Called during round reset.
 func clear_discard_pile() -> Array[Tile]:
-	var tiles: Array[Tile] = discard_pile.duplicate()
-	discard_pile.clear()
+	var tiles: Array[Tile] = _discard_pile.duplicate()
+	_discard_pile.clear()
 	EventBus.discard_count_changed.emit(0)
 	EventBus.discard_pile_changed.emit([])
 	return tiles

--- a/autoload/run_manager.gd
+++ b/autoload/run_manager.gd
@@ -50,6 +50,7 @@ func initialize_run(
 	hand_size: int = 10,
 	progression_config: ProgressionConfig = null
 ) -> void:
+	_debug_auto_win = false
 	run_state = RunState.new()
 	run_state.start_run(plays_per_round, hand_size, bag_config)
 
@@ -63,6 +64,7 @@ func initialize_run(
 
 ## Initializes a run from a Run object built by RunBuilder.
 func initialize_run_from_builder(run: Run) -> void:
+	_debug_auto_win = false
 	_active_run = run
 
 	# Set up RunState from the Run config
@@ -111,6 +113,7 @@ func get_active_run() -> Run:
 
 
 ## Resets all run state (for returning to title).
+## Postcondition: all run state is null/zero/false — no previous run bleeds into the next.
 func reset() -> void:
 	_disconnect_quality_signals()
 	_active_run = null
@@ -118,6 +121,7 @@ func reset() -> void:
 	progression_rules = null
 	current_round_config = null
 	_debug_override_board_size = Vector2i.ZERO
+	_debug_auto_win = false
 	print("[RunManager] Reset")
 
 

--- a/autoload/run_manager.gd
+++ b/autoload/run_manager.gd
@@ -185,12 +185,18 @@ func _connect_quality_signals() -> void:
 
 
 func _disconnect_quality_signals() -> void:
+	if _quality_connections.is_empty():
+		return
 	for conn in _quality_connections:
 		var sig: Signal = conn["signal"]
 		var cb: Callable = conn["callable"]
+		# Guard: quality signals may originate from RefCounted objects that were freed
+		if not is_instance_valid(sig.get_object()):
+			continue
 		if sig.is_connected(cb):
 			sig.disconnect(cb)
 	_quality_connections.clear()
+	print("[RunManager] Quality signals disconnected")
 
 
 func _on_quality_time_expired() -> void:

--- a/autoload/run_manager.gd
+++ b/autoload/run_manager.gd
@@ -14,7 +14,7 @@ var current_round_config: RoundConfig = null
 
 # Run builder integration
 var _active_run: Run = null
-var _quality_connections: Array[Dictionary] = []
+var _quality_tracker: SignalTracker = SignalTracker.new()
 
 # Debug overrides
 var _debug_override_board_size: Vector2i = Vector2i.ZERO  # Zero = no override
@@ -42,25 +42,6 @@ func _process(delta: float) -> void:
 # =============================================================================
 # PUBLIC API: RUN LIFECYCLE
 # =============================================================================
-
-## Initializes a new run. Call BEFORE changing scene to Main.
-func initialize_run(
-	bag_config: BagDistribution,
-	plays_per_round: int = 2,
-	hand_size: int = 10,
-	progression_config: ProgressionConfig = null
-) -> void:
-	_debug_auto_win = false
-	run_state = RunState.new()
-	run_state.start_run(plays_per_round, hand_size, bag_config)
-
-	if progression_config == null:
-		progression_config = load("res://Data/Progression/progression_default.tres")
-	progression_rules = ProgressionRules.new(progression_config)
-
-	_active_run = null
-	print("[RunManager] Run initialized - Plays/round: %d | Hand: %d" % [plays_per_round, hand_size])
-
 
 ## Initializes a run from a Run object built by RunBuilder.
 func initialize_run_from_builder(run: Run) -> void:
@@ -161,41 +142,27 @@ func _connect_quality_signals() -> void:
 	var round_started_cb := func(round_number: int) -> void:
 		for quality in _active_run.qualities:
 			quality.on_round_started(round_number)
-	EventBus.round_started.connect(round_started_cb)
-	_quality_connections.append({"signal": EventBus.round_started, "callable": round_started_cb})
+	_quality_tracker.track(EventBus.round_started, round_started_cb)
 
 	var play_completed_cb := func(plays_remaining: int) -> void:
 		for quality in _active_run.qualities:
 			quality.on_play_completed(plays_remaining)
-	EventBus.play_completed.connect(play_completed_cb)
-	_quality_connections.append({"signal": EventBus.play_completed, "callable": play_completed_cb})
+	_quality_tracker.track(EventBus.play_completed, play_completed_cb)
 
 	var score_updated_cb := func(total_score: int, delta: int) -> void:
 		for quality in _active_run.qualities:
 			quality.on_score_updated(total_score, delta)
-	EventBus.score_updated.connect(score_updated_cb)
-	_quality_connections.append({"signal": EventBus.score_updated, "callable": score_updated_cb})
+	_quality_tracker.track(EventBus.score_updated, score_updated_cb)
 
 	# Connect timer expiry signals from each quality
 	for quality in _active_run.qualities:
 		var expired_cb := func() -> void:
 			_on_quality_time_expired()
-		quality.time_expired.connect(expired_cb)
-		_quality_connections.append({"signal": quality.time_expired, "callable": expired_cb})
+		_quality_tracker.track(quality.time_expired, expired_cb)
 
 
 func _disconnect_quality_signals() -> void:
-	if _quality_connections.is_empty():
-		return
-	for conn in _quality_connections:
-		var sig: Signal = conn["signal"]
-		var cb: Callable = conn["callable"]
-		# Guard: quality signals may originate from RefCounted objects that were freed
-		if not is_instance_valid(sig.get_object()):
-			continue
-		if sig.is_connected(cb):
-			sig.disconnect(cb)
-	_quality_connections.clear()
+	_quality_tracker.disconnect_all()
 	print("[RunManager] Quality signals disconnected")
 
 
@@ -230,33 +197,41 @@ func _advance_to_next_round() -> void:
 	print("[RunManager] %s" % current_round_config)
 
 
+## Checks if any quality wants to end the run. Handles the transition if so.
+## Returns true if the run was ended (caller should return early).
+func _check_quality_win_conditions() -> bool:
+	if _active_run == null:
+		return false
+	for quality in _active_run.qualities:
+		if not quality.has_custom_win_condition():
+			continue
+		var result := quality.check_run_end_condition(run_state)
+		if not result.get("should_end", false):
+			continue
+		var victory: bool = result.get("victory", false)
+		run_state.end_run()
+		EventBus.run_ended.emit(victory, run_state.total_score)
+		print("[RunManager] Quality '%s' ended run - Victory: %s" % [quality.get_quality_name(), victory])
+		return true
+	return false
+
+
 func _on_round_ended(round_number: int, success: bool) -> void:
 	if not run_state or not run_state.is_run_active:
 		return
 
-	# Forward to qualities
 	if _active_run:
 		for quality in _active_run.qualities:
 			quality.on_round_ended(round_number, success)
 
-	if success:
-		run_state.complete_round(GameManager.get_current_score())
-
-		# Check custom win conditions from qualities
-		if _active_run:
-			for quality in _active_run.qualities:
-				if quality.has_custom_win_condition():
-					var result := quality.check_run_end_condition(run_state)
-					if result.get("should_end", false):
-						var victory: bool = result.get("victory", false)
-						run_state.end_run()
-						EventBus.run_ended.emit(victory, run_state.total_score)
-						print("[RunManager] Quality '%s' ended run - Victory: %s" % [quality.get_quality_name(), victory])
-						return
-
-		EventBus.run_shop_requested.emit(run_state.current_round)
-		print("[RunManager] Round %d won - proceeding to shop" % round_number)
-	else:
+	if not success:
 		run_state.end_run()
 		EventBus.run_ended.emit(false, run_state.total_score)
 		print("[RunManager] Round %d lost - run ended" % round_number)
+		return
+
+	run_state.complete_round(GameManager.get_current_score())
+	if _check_quality_win_conditions():
+		return
+	EventBus.run_shop_requested.emit(run_state.current_round)
+	print("[RunManager] Round %d won - proceeding to shop" % round_number)

--- a/autoload/tile_animator.gd
+++ b/autoload/tile_animator.gd
@@ -150,36 +150,36 @@ func cancel_tile_animation(tile: Tile) -> void:
 # PRIVATE: LAZY INITIALIZATION
 # =============================================================================
 
+## Lazy-initializes a strategy (no constructor args).
+func _ensure_strategy(current: Variant, klass: GDScript) -> Variant:
+	return current if current != null else klass.new()
+
+
+## Lazy-initializes an executor (takes _context as constructor arg).
+func _ensure_executor(current: Variant, klass: GDScript) -> Variant:
+	return current if current != null else klass.new(_context)
+
+
 func _ensure_draw_resources() -> void:
-	if _draw_animation == null:
-		_draw_animation = DrawTileAnimation.new()
-	if _batch_executor == null:
-		_batch_executor = BatchAnimationExecutor.new(_context)
+	_draw_animation = _ensure_strategy(_draw_animation, DrawTileAnimation)
+	_batch_executor = _ensure_executor(_batch_executor, BatchAnimationExecutor)
 
 
 func _ensure_glide_resources() -> void:
-	if _glide_animation == null:
-		_glide_animation = GlideTileAnimation.new()
-	if _return_executor == null:
-		_return_executor = ReturnAnimationExecutor.new(_context)
+	_glide_animation = _ensure_strategy(_glide_animation, GlideTileAnimation)
+	_return_executor = _ensure_executor(_return_executor, ReturnAnimationExecutor)
 
 
 func _ensure_shake_resources() -> void:
-	if _shake_animation == null:
-		_shake_animation = ShakeTileAnimation.new()
-	if _shake_executor == null:
-		_shake_executor = ShakeAnimationExecutor.new(_context)
+	_shake_animation = _ensure_strategy(_shake_animation, ShakeTileAnimation)
+	_shake_executor = _ensure_executor(_shake_executor, ShakeAnimationExecutor)
 
 
 func _ensure_stomp_resources() -> void:
-	if _stomp_animation == null:
-		_stomp_animation = StompTileAnimation.new()
-	if _stomp_executor == null:
-		_stomp_executor = StompAnimationExecutor.new(_context)
+	_stomp_animation = _ensure_strategy(_stomp_animation, StompTileAnimation)
+	_stomp_executor = _ensure_executor(_stomp_executor, StompAnimationExecutor)
 
 
 func _ensure_spin_resources() -> void:
-	if _spin_animation == null:
-		_spin_animation = SpinTileAnimation.new()
-	if _spin_executor == null:
-		_spin_executor = SpinAnimationExecutor.new(_context)
+	_spin_animation = _ensure_strategy(_spin_animation, SpinTileAnimation)
+	_spin_executor = _ensure_executor(_spin_executor, SpinAnimationExecutor)

--- a/autoload/tile_bag.gd
+++ b/autoload/tile_bag.gd
@@ -17,10 +17,20 @@ var _tile_scene: PackedScene = null
 # STATE
 # =============================================================================
 
-var available_tiles: Array[Tile] = []
-var drawn_tiles: Array[Tile] = []
-var current_distribution: BagDistribution = null
+var _available_tiles: Array[Tile] = []
+var _drawn_tiles: Array[Tile] = []
+var _current_distribution: BagDistribution = null
 var _initial_count: int = 0
+
+
+func get_available_tiles() -> Array[Tile]:
+	return _available_tiles.duplicate()
+
+func get_drawn_tiles() -> Array[Tile]:
+	return _drawn_tiles.duplicate()
+
+func get_current_distribution() -> BagDistribution:
+	return _current_distribution
 
 
 func _ready() -> void:
@@ -39,7 +49,7 @@ func populate_bag(distribution: BagDistribution) -> bool:
 		return false
 
 	_clear_all_tiles()
-	current_distribution = distribution
+	_current_distribution = distribution
 
 	for letter in distribution.distribution.keys():
 		var count: int = distribution.distribution[letter]
@@ -51,30 +61,30 @@ func populate_bag(distribution: BagDistribution) -> bool:
 		for i in count:
 			var tile: Tile = _create_tile(tile_data)
 			if tile:
-				available_tiles.append(tile)
+				_available_tiles.append(tile)
 
-	_initial_count = available_tiles.size()
+	_initial_count = _available_tiles.size()
 	shuffle_bag()
 
-	print("[TileBag] Populated with %d tiles" % available_tiles.size())
+	print("[TileBag] Populated with %d tiles" % _available_tiles.size())
 	return true
 
 
 ## Shuffles the available tiles randomly.
 func shuffle_bag() -> void:
-	available_tiles.shuffle()
+	_available_tiles.shuffle()
 
 
 ## Resets the bag to initial state (returns all drawn tiles).
 func reset_bag() -> void:
-	for tile in drawn_tiles:
+	for tile in _drawn_tiles:
 		tile.reset()
-		available_tiles.append(tile)
+		_available_tiles.append(tile)
 
-	drawn_tiles.clear()
+	_drawn_tiles.clear()
 	shuffle_bag()
 
-	print("[TileBag] Reset - %d tiles available" % available_tiles.size())
+	print("[TileBag] Reset - %d tiles available" % _available_tiles.size())
 
 
 # =============================================================================
@@ -83,15 +93,15 @@ func reset_bag() -> void:
 
 ## Draws a single tile from the bag.
 func draw_tile() -> Tile:
-	if available_tiles.is_empty():
+	if _available_tiles.is_empty():
 		print("[TileBag] Empty - cannot draw")
 		return null
 
-	var tile: Tile = available_tiles.pop_back()
-	drawn_tiles.append(tile)
+	var tile: Tile = _available_tiles.pop_back()
+	_drawn_tiles.append(tile)
 
 	EventBus.tile_drawn.emit(tile)
-	print("[TileBag] Drew: %s | Remaining: %d" % [tile.letter, available_tiles.size()])
+	print("[TileBag] Drew: %s | Remaining: %d" % [tile.letter, _available_tiles.size()])
 
 	return tile
 
@@ -111,14 +121,14 @@ func draw_tiles(count: int) -> Array[Tile]:
 
 ## Returns a tile to the bag (for special effects).
 func return_tile(tile: Tile) -> void:
-	if tile in drawn_tiles:
-		drawn_tiles.erase(tile)
+	if tile in _drawn_tiles:
+		_drawn_tiles.erase(tile)
 
 	tile.reset()
-	available_tiles.append(tile)
+	_available_tiles.append(tile)
 	shuffle_bag()
 
-	print("[TileBag] Returned: %s | Available: %d" % [tile.letter, available_tiles.size()])
+	print("[TileBag] Returned: %s | Available: %d" % [tile.letter, _available_tiles.size()])
 
 
 # =============================================================================
@@ -127,12 +137,12 @@ func return_tile(tile: Tile) -> void:
 
 ## Returns the number of tiles remaining in the bag.
 func tiles_remaining() -> int:
-	return available_tiles.size()
+	return _available_tiles.size()
 
 
 ## Returns true if the bag is empty.
 func is_empty() -> bool:
-	return available_tiles.is_empty()
+	return _available_tiles.is_empty()
 
 
 ## Returns the initial tile count when bag was populated.
@@ -142,16 +152,16 @@ func get_initial_count() -> int:
 
 ## Returns the number of tiles that have been drawn.
 func get_drawn_count() -> int:
-	return drawn_tiles.size()
+	return _drawn_tiles.size()
 
 
 ## Peeks at the top N tiles without drawing them (for debugging).
 func peek_tiles(count: int) -> Array[Tile]:
 	var result: Array[Tile] = []
-	var peek_count: int = mini(count, available_tiles.size())
+	var peek_count: int = mini(count, _available_tiles.size())
 
-	for i in range(available_tiles.size() - peek_count, available_tiles.size()):
-		result.append(available_tiles[i])
+	for i in range(_available_tiles.size() - peek_count, _available_tiles.size()):
+		result.append(_available_tiles[i])
 
 	return result
 
@@ -183,13 +193,13 @@ func _create_tile(data: LetterTileData) -> Tile:
 
 
 func _clear_all_tiles() -> void:
-	for tile in available_tiles:
+	for tile in _available_tiles:
 		if is_instance_valid(tile):
 			tile.queue_free()
-	for tile in drawn_tiles:
+	for tile in _drawn_tiles:
 		if is_instance_valid(tile):
 			tile.queue_free()
 
-	available_tiles.clear()
-	drawn_tiles.clear()
+	_available_tiles.clear()
+	_drawn_tiles.clear()
 	_initial_count = 0

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -1,0 +1,27 @@
+# Documentation Directory
+
+## Purpose
+Contains project documentation, design documents, and planning materials for the Wordatro game.
+
+## Key Files
+- `plans/` - Feature design and implementation plans
+
+## Public Interfaces
+None (documentation only)
+
+## Dependencies
+None
+
+## Architecture / Patterns
+- Documentation follows Markdown format
+- Design documents dated with ISO format (YYYY-MM-DD)
+- Plans include both design specifications and implementation steps
+
+## Conventions
+- File naming: `YYYY-MM-DD-feature-type.md` (e.g., `2026-02-21-decks-design.md`)
+- Design documents separate from implementation plans
+- Design status tracked: Draft, Approved, Implemented
+- Implementation plans include step-by-step instructions for developers
+
+## Build / Test
+None (documentation only)

--- a/docs/plans/2026-02-21-cleanup-design.md
+++ b/docs/plans/2026-02-21-cleanup-design.md
@@ -1,0 +1,277 @@
+# Cleanup Design — OOP/DDD Enforcement, Immutability, Complexity Reduction
+
+**Date:** 2026-02-21
+**Branch:** cleanup (from decks)
+**Status:** Approved
+
+---
+
+## Goals
+
+1. Remove dead and half-baked code.
+2. Enforce encapsulation — no public mutable state that should be private.
+3. Enforce immutability at API boundaries — public getters return copies, not references.
+4. Cyclomatic complexity ≤ 5 on all functions; decompose any that exceed it.
+5. High-frequency, low-verbosity patterns — one canonical way to do each recurring concern.
+
+---
+
+## Design Principles
+
+- OOP: state owned by one class, accessed through its API.
+- DDD: domain handlers have zero UI knowledge; controllers wire signals to UI.
+- Immutability: autoload state arrays exposed read-only via getters returning duplicates.
+- YAGNI: remove unused code, not replace it with more abstractions.
+- Cyclomatic complexity ≤ 5: extract named helpers at the point of violation.
+
+---
+
+## Phase 1 — Dead Code + Encapsulation
+
+**Scope:** Pure subtraction and renaming. Zero behavior change. Safe to merge independently.
+
+### Dead code removed
+
+| File | Symbol | Reason |
+|------|---------|--------|
+| `scenes/tile/tile.gd` | `is_wild: bool` | Marked "(unused)" in docstring |
+| `scenes/tile/tile.gd` | `point_modifier` | Marked "Legacy" |
+| `scripts/animation/draw/draw_tile_animation.gd` | `start_alpha: float` | `@export` var never read; alpha hardcoded in `on_animation_start()` |
+| `autoload/run_manager.gd` | `initialize_run()` | Legacy path with inconsistent defaults; `initialize_run_from_builder()` is the only path |
+
+### Encapsulation fixes
+
+**TileBag** — all three state arrays become private:
+
+```gdscript
+# before
+var available_tiles: Array[Tile] = []
+var drawn_tiles: Array[Tile] = []
+var current_distribution: BagDistribution = null
+
+# after
+var _available_tiles: Array[Tile] = []
+var _drawn_tiles: Array[Tile] = []
+var _current_distribution: BagDistribution = null
+
+func get_available_tiles() -> Array[Tile]:
+    return _available_tiles.duplicate()
+
+func get_drawn_tiles() -> Array[Tile]:
+    return _drawn_tiles.duplicate()
+
+func get_current_distribution() -> BagDistribution:
+    return _current_distribution
+```
+
+Callers updated: `RandomModifiersQuality`, `AllResetQuality`, any debug commands.
+
+**HandManager** — discard pile becomes private:
+
+```gdscript
+# before
+var discard_pile: Array[Tile] = []
+
+# after
+var _discard_pile: Array[Tile] = []
+# get_discard_pile() already exists — no new API needed
+```
+
+**GameplayController** — internal state becomes private:
+
+```gdscript
+# before
+var interaction_mode: InteractionMode = InteractionMode.IDLE
+var selected_tile: Tile = null
+
+# after
+var _interaction_mode: InteractionMode = InteractionMode.IDLE
+var _selected_tile: Tile = null
+# Add getters only if external callers exist
+```
+
+**DropHandler** — remove state flag, use return value:
+
+```gdscript
+# before
+var last_placement_success: bool = false  # read by coordinator
+# handle_tile_drop() already returns bool
+
+# after
+# field removed; callers use: var ok := _drop.handle_tile_drop(...)
+```
+
+---
+
+## Phase 2 — Complexity Reduction
+
+**Scope:** Behavior-preserving restructuring. Each function after refactor does the same thing with CC ≤ 5.
+
+### PlayHandler — animation dispatch deduplication
+
+The 11-line categorization block is identical in `on_play_requested()` and `_auto_end_round()`.
+
+```gdscript
+# extracted helper (CC 3)
+func _categorize_tiles_by_animation(tiles: Array[Tile]) -> Dictionary:
+    var spin: Array[Tile] = []
+    var stomp: Array[Tile] = []
+    for tile in tiles:
+        if tile.has_modifier(ModifierTypes.Type.RESET):
+            stomp.append(tile)
+        elif tile.has_modifier(ModifierTypes.Type.EXTRA) \
+            or tile.has_modifier(ModifierTypes.Type.MULTI) \
+            or tile.has_modifier(ModifierTypes.Type.EXPO):
+            spin.append(tile)
+        else:
+            stomp.append(tile)
+    return {spin = spin, stomp = stomp}
+```
+
+Both callers replaced with one line: `var cats := _categorize_tiles_by_animation(tiles)`.
+
+CC `on_play_requested()`: 7 → ≤ 5
+CC `_auto_end_round()`: 6 → ≤ 5
+
+### GameplayController — drag and cell-click decomposition
+
+`_on_tile_drag_started()` (CC 7): extract `_collect_drag_candidates(tile) -> Array[Tile]`.
+`_on_cell_clicked()` (CC 6): extract `_place_tiles_on_cell(movable: Array[Tile], cell: BoardCell)`.
+`_on_tile_selected()` (CC 5): replace sequential `if/elif` with `match tile.location`.
+
+### RunManager — win condition check extraction
+
+`_on_round_ended()` (CC 6): extract `_check_quality_win_conditions() -> Dictionary` returning `{should_end, victory}`.
+
+### RandomModifiersQuality — weighted picker deduplication
+
+`_pick_weighted_type()` and `_pick_weighted_tier()` are identical in structure (CC 6 each).
+
+```gdscript
+# extracted helper
+func _pick_weighted(weights: Dictionary) -> Variant:
+    var total: int = 0
+    for w in weights.values(): total += w
+    var roll := randi() % total
+    var cumulative := 0
+    for key in weights:
+        cumulative += weights[key]
+        if roll < cumulative:
+            return key
+    return weights.keys()[0]
+```
+
+Both callers become one-liners. CC: 6 → 2 each.
+
+---
+
+## Phase 3 — Architecture Patterns
+
+**Scope:** New types introduced, signal wiring changed. Most reviewable phase in isolation.
+
+### SignalTracker (new file: `scripts/util/signal_tracker.gd`)
+
+One canonical pattern for signal lifecycle management across the codebase.
+
+```gdscript
+class_name SignalTracker
+extends RefCounted
+
+var _connections: Array[Dictionary] = []
+
+func track(sig: Signal, fn: Callable) -> void:
+    sig.connect(fn)
+    _connections.append({s = sig, f = fn})
+
+func disconnect_all() -> void:
+    for c in _connections:
+        if c.s.is_connected(c.f):
+            c.s.disconnect(c.f)
+    _connections.clear()
+```
+
+**GameplayController**: replaces `_safe_connect()`, `_disconnect_all()`, `_connections` array with `_tracker: SignalTracker`.
+**RunManager**: replaces `_quality_connections` inline tracking with `_quality_tracker: SignalTracker`.
+
+### TimerQuality base class (new file: `scripts/domain/qualities/timer_quality.gd`)
+
+Shared countdown logic extracted from both timer qualities.
+
+```gdscript
+class_name TimerQuality
+extends RunQuality
+
+var _time_remaining: float = 0.0
+
+func on_process(delta: float) -> void:
+    _time_remaining = maxf(0.0, _time_remaining - delta)
+    time_updated.emit(_time_remaining)
+    if _time_remaining <= 0.0:
+        time_expired.emit()
+```
+
+`TimeAttackQuality`: extends `TimerQuality`, sets `_time_remaining` in `on_round_started()`.
+`LimitedTimeWithIncrementQuality`: extends `TimerQuality`, adds `_increment` in `on_round_started()`.
+
+### PlayHandler — UI decoupling via signals
+
+```gdscript
+# play_handler.gd
+signal draw_blocked_changed(blocked: bool)
+signal play_button_changed(enabled: bool, end_round_mode: bool)
+
+# replaces: main_hud.set_draw_button_blocked(true)
+draw_blocked_changed.emit(true)
+```
+
+`setup()` loses `main_hud` parameter. `GameplayController.setup()` connects the two signals to `main_hud` calls after constructing `_play`.
+
+### TileAnimator — generic lazy-loader
+
+5 identical `_ensure_*_resources()` methods collapsed to one helper:
+
+```gdscript
+func _ensure(s_ref: RefCounted, e_ref: RefCounted, s_class: GDScript, e_class: GDScript) -> Array:
+    if not s_ref: s_ref = s_class.new()
+    if not e_ref: e_ref = e_class.new()
+    return [s_ref, e_ref]
+```
+
+Each of the 5 callers becomes: `[_spin_strategy, _spin_executor] = _ensure(...)`.
+
+---
+
+## Files Changed
+
+| Phase | File | Change type |
+|-------|------|-------------|
+| 1 | `scenes/tile/tile.gd` | Remove `is_wild`, `point_modifier` |
+| 1 | `scripts/animation/draw/draw_tile_animation.gd` | Remove `start_alpha` |
+| 1 | `autoload/run_manager.gd` | Remove `initialize_run()` |
+| 1 | `autoload/tile_bag.gd` | Private fields + getters |
+| 1 | `autoload/hand_manager.gd` | Private `_discard_pile` |
+| 1 | `scripts/controllers/gameplay_controller.gd` | Private `_interaction_mode`, `_selected_tile` |
+| 1 | `scripts/controllers/drop_handler.gd` | Remove `last_placement_success` |
+| 1 | (callers of above) | Update to new API |
+| 2 | `scripts/controllers/play_handler.gd` | Extract `_categorize_tiles_by_animation()` |
+| 2 | `scripts/controllers/gameplay_controller.gd` | Extract drag/cell helpers, use match |
+| 2 | `autoload/run_manager.gd` | Extract `_check_quality_win_conditions()` |
+| 2 | `scripts/domain/qualities/random_modifiers_quality.gd` | Extract `_pick_weighted()` |
+| 3 | `scripts/util/signal_tracker.gd` | **New file** |
+| 3 | `scripts/domain/qualities/timer_quality.gd` | **New file** |
+| 3 | `scripts/controllers/gameplay_controller.gd` | Use SignalTracker |
+| 3 | `autoload/run_manager.gd` | Use SignalTracker |
+| 3 | `scripts/controllers/play_handler.gd` | Signals instead of HUD calls |
+| 3 | `scripts/domain/qualities/time_attack_quality.gd` | Extend TimerQuality |
+| 3 | `scripts/domain/qualities/limited_time_with_increment_quality.gd` | Extend TimerQuality |
+| 3 | `autoload/tile_animator.gd` | Generic `_ensure()` helper |
+
+---
+
+## Out of Scope
+
+- `RunSetupPopup._populate_quality_list()` CC 5 — borderline, layout logic acceptable inline.
+- `DebugManager` hardcoded node paths — debug tooling, low priority.
+- `tile_placement_handler.gd` missing null check for `tile_anchor` — separate bug fix if needed.
+- Game configuration TODOs (refill behavior, plays per round) — product decisions, not code quality.
+- `MaxScoreInNRoundsQuality` semantic mismatch ("Sprint") — naming cleanup separate from this.

--- a/docs/plans/2026-02-21-cleanup-plan.md
+++ b/docs/plans/2026-02-21-cleanup-plan.md
@@ -1,0 +1,1362 @@
+# Cleanup Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Remove dead code, enforce encapsulation and immutability, reduce cyclomatic complexity to ≤ 5, and unify high-frequency patterns.
+
+**Architecture:** Three sequential phases — Phase 1 is pure subtraction (safe to merge alone), Phase 2 is behavior-preserving restructuring, Phase 3 introduces two new types and rewires signal plumbing.
+
+**Tech Stack:** Godot 4.5.1, GDScript. No test framework — verification is editor error-free + F5 run.
+
+---
+
+## Phase 1 — Dead Code + Encapsulation
+
+---
+
+### Task 1: Remove `is_wild` and `point_modifier` from Tile
+
+**Files:**
+- Modify: `scenes/tile/tile.gd`
+
+**Step 1: Remove the two dead fields and fix their sole usages**
+
+In `tile.gd`, find and apply all four edits below:
+
+Remove lines 37–38 (the two field declarations):
+```gdscript
+# DELETE these two lines:
+var point_modifier: int = 0        # Bonus/penalty to base points
+var is_wild: bool = false          # Wild card tile (unused)
+```
+
+Fix `get_points()` (was using `point_modifier`):
+```gdscript
+# BEFORE (line ~162):
+func get_points() -> int:
+	return base_points + point_modifier
+
+# AFTER:
+func get_points() -> int:
+	return base_points
+```
+
+Fix `reset()` (was resetting `point_modifier`):
+```gdscript
+# BEFORE (line ~266) — remove the point_modifier line:
+	point_modifier = 0
+	modifiers.clear()
+
+# AFTER:
+	modifiers.clear()
+```
+
+**Step 2: Search for any other callers**
+
+```
+grep -r "point_modifier\|is_wild" --include="*.gd" .
+```
+
+Expected: zero results after editing. If any appear, remove them.
+
+**Step 3: Verify in Godot**
+
+Open Godot editor. Check Output panel for script errors. Expected: none.
+
+**Step 4: Commit**
+
+```bash
+git add scenes/tile/tile.gd
+git commit -m "refactor: remove unused Tile.is_wild and legacy Tile.point_modifier"
+```
+
+---
+
+### Task 2: Remove `start_alpha` from DrawTileAnimation
+
+**Files:**
+- Modify: `scripts/animation/draw/draw_tile_animation.gd`
+
+**Step 1: Delete the unused export**
+
+```gdscript
+# DELETE line 13:
+@export var start_alpha: float = 0.0  # Currently unused; alpha set directly in on_animation_start
+```
+
+The comment in `on_animation_start` is now redundant too — clean it:
+
+```gdscript
+# BEFORE (lines 37–39):
+func on_animation_start(tile: Tile) -> void:
+	# Disable interaction during animation
+	tile.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	# Apply modifier visual first (tint + invert), then set alpha to 0
+	tile._apply_modifier_visual()
+	tile.modulate.a = 0.0
+
+# AFTER:
+func on_animation_start(tile: Tile) -> void:
+	tile.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	tile._apply_modifier_visual()
+	tile.modulate.a = 0.0
+```
+
+**Step 2: Verify in Godot**
+
+Open editor. Expected: no errors. Draw a tile via F5 — animation should still fade in from below.
+
+**Step 3: Commit**
+
+```bash
+git add scripts/animation/draw/draw_tile_animation.gd
+git commit -m "refactor: remove unused DrawTileAnimation.start_alpha export"
+```
+
+---
+
+### Task 3: Remove legacy `RunManager.initialize_run()`
+
+**Files:**
+- Modify: `autoload/run_manager.gd`
+
+**Step 1: Find the function**
+
+```
+grep -n "func initialize_run\b" autoload/run_manager.gd
+```
+
+**Step 2: Find all callers**
+
+```
+grep -rn "initialize_run(" --include="*.gd" .
+```
+
+Expected callers: only `initialize_run_from_builder` (different name). If `initialize_run(` (without `_from_builder`) appears anywhere, update those callers to use the builder path before proceeding.
+
+**Step 3: Delete the function**
+
+Remove the entire `func initialize_run(...)` block from `run_manager.gd`. It spans roughly 15 lines with parameters `bag_config`, `plays_per_round`, `hand_size`, `progression_config`.
+
+**Step 4: Verify**
+
+```
+grep -rn "\.initialize_run(" --include="*.gd" .
+```
+
+Expected: zero results (only `initialize_run_from_builder` should remain).
+
+Open Godot. Expected: no errors.
+
+**Step 5: Commit**
+
+```bash
+git add autoload/run_manager.gd
+git commit -m "refactor: remove legacy RunManager.initialize_run() in favour of builder path"
+```
+
+---
+
+### Task 4: Encapsulate `TileBag` state arrays
+
+**Files:**
+- Modify: `autoload/tile_bag.gd`
+- Modify: `scripts/domain/qualities/random_modifiers_quality.gd`
+- Modify: `scripts/domain/qualities/all_reset_quality.gd`
+
+**Step 1: Find all direct callers of the public arrays**
+
+```
+grep -rn "TileBag\.available_tiles\|TileBag\.drawn_tiles\|TileBag\.current_distribution" --include="*.gd" .
+```
+
+Note every file and line that appears.
+
+**Step 2: Rename fields and add getters in `tile_bag.gd`**
+
+```gdscript
+# BEFORE (lines 20–22):
+var available_tiles: Array[Tile] = []
+var drawn_tiles: Array[Tile] = []
+var current_distribution: BagDistribution = null
+
+# AFTER:
+var _available_tiles: Array[Tile] = []
+var _drawn_tiles: Array[Tile] = []
+var _current_distribution: BagDistribution = null
+```
+
+Add getters immediately after the state block (before `_ready`):
+
+```gdscript
+func get_available_tiles() -> Array[Tile]:
+	return _available_tiles.duplicate()
+
+func get_drawn_tiles() -> Array[Tile]:
+	return _drawn_tiles.duplicate()
+
+func get_current_distribution() -> BagDistribution:
+	return _current_distribution
+```
+
+**Step 3: Fix all internal usages in `tile_bag.gd`**
+
+Every reference to `available_tiles`, `drawn_tiles`, `current_distribution` inside the file must gain the underscore prefix. Use search-and-replace within the file only:
+
+- `available_tiles` → `_available_tiles`
+- `drawn_tiles` → `_drawn_tiles`
+- `current_distribution` → `_current_distribution`
+
+Key lines to verify after:
+- `populate_bag()`: uses `_available_tiles.append(tile)`, sets `_current_distribution = distribution`
+- `shuffle_bag()`: calls `_available_tiles.shuffle()`
+- `reset_bag()`: iterates `_drawn_tiles`, appends to `_available_tiles`
+- `draw_tile()`: pops from `_available_tiles`, appends to `_drawn_tiles`
+- `tiles_remaining()`: returns `_available_tiles.size()`
+- `is_empty()`: checks `_available_tiles.is_empty()`
+
+**Step 4: Update `random_modifiers_quality.gd`**
+
+```gdscript
+# BEFORE (line 38):
+	for tile in TileBag.available_tiles:
+
+# AFTER:
+	for tile in TileBag.get_available_tiles():
+```
+
+```gdscript
+# BEFORE (line 45–46):
+	print("[RandomModifiers] Assigned %d modifiers to %d available tiles" % [
+		count, TileBag.available_tiles.size()
+	])
+
+# AFTER:
+	print("[RandomModifiers] Assigned %d modifiers to %d available tiles" % [
+		count, TileBag.tiles_remaining()
+	])
+```
+
+**Step 5: Update `all_reset_quality.gd`**
+
+Open the file. Find every `TileBag.available_tiles` reference and replace with `TileBag.get_available_tiles()`.
+
+**Step 6: Update any remaining callers from the grep in Step 1**
+
+**Step 7: Verify**
+
+```
+grep -rn "TileBag\.available_tiles\|TileBag\.drawn_tiles\|TileBag\.current_distribution" --include="*.gd" .
+```
+
+Expected: zero results.
+
+Open Godot. F5 — run a game, confirm tiles draw normally.
+
+**Step 8: Commit**
+
+```bash
+git add autoload/tile_bag.gd scripts/domain/qualities/random_modifiers_quality.gd scripts/domain/qualities/all_reset_quality.gd
+git commit -m "refactor: encapsulate TileBag state arrays behind read-only getters"
+```
+
+---
+
+### Task 5: Encapsulate `HandManager.discard_pile`
+
+**Files:**
+- Modify: `autoload/hand_manager.gd`
+
+**Step 1: Find all direct callers**
+
+```
+grep -rn "HandManager\.discard_pile\b" --include="*.gd" .
+```
+
+Note each caller. Any code reading `HandManager.discard_pile` directly should use `HandManager.get_discard_pile()` instead (that getter already exists).
+
+**Step 2: Rename the field**
+
+```gdscript
+# BEFORE (line 24):
+var discard_pile: Array[Tile] = []
+
+# AFTER:
+var _discard_pile: Array[Tile] = []
+```
+
+**Step 3: Fix internal usages in `hand_manager.gd`**
+
+Replace all `discard_pile` with `_discard_pile` within the file. The public `get_discard_pile()`, `clear_discard_pile()`, `discard_tile()` methods should all update their internal references.
+
+**Step 4: Fix any external callers from Step 1**
+
+For each caller found: replace direct array access with the appropriate method (`get_discard_pile()`, `discard_tile()`, `clear_discard_pile()`).
+
+**Step 5: Verify**
+
+```
+grep -rn "HandManager\.discard_pile\b" --include="*.gd" .
+```
+
+Expected: zero results.
+
+Open Godot. F5 — discard tiles, confirm they move to discard pile correctly.
+
+**Step 6: Commit**
+
+```bash
+git add autoload/hand_manager.gd
+git commit -m "refactor: encapsulate HandManager.discard_pile as _discard_pile"
+```
+
+---
+
+### Task 6: Make `GameplayController` internal state private
+
+**Files:**
+- Modify: `scripts/controllers/gameplay_controller.gd`
+
+**Step 1: Find external readers**
+
+```
+grep -rn "gameplay_controller\.\(interaction_mode\|selected_tile\)\|controller\.\(interaction_mode\|selected_tile\)" --include="*.gd" .
+```
+
+If any external caller reads `interaction_mode`, add `func get_interaction_mode() -> InteractionMode: return _interaction_mode`. Same for `selected_tile`.
+
+**Step 2: Rename the fields**
+
+```gdscript
+# BEFORE (lines 30–31):
+var interaction_mode: InteractionMode = InteractionMode.IDLE
+var selected_tile: Tile = null
+
+# AFTER:
+var _interaction_mode: InteractionMode = InteractionMode.IDLE
+var _selected_tile: Tile = null
+```
+
+**Step 3: Fix all internal usages**
+
+In `_update_interaction_state()` (line ~375):
+
+```gdscript
+# BEFORE:
+	if has_selection:
+		interaction_mode = InteractionMode.TILE_SELECTED
+		selected_tile = _selection.get_selected_tiles()[0] if _selection.get_selection_count() == 1 else null
+		...
+	else:
+		interaction_mode = InteractionMode.IDLE
+		selected_tile = null
+
+# AFTER:
+	if has_selection:
+		_interaction_mode = InteractionMode.TILE_SELECTED
+		_selected_tile = _selection.get_selected_tiles()[0] if _selection.get_selection_count() == 1 else null
+		...
+	else:
+		_interaction_mode = InteractionMode.IDLE
+		_selected_tile = null
+```
+
+**Step 4: Verify**
+
+```
+grep -n "\binteraction_mode\b\|\bselected_tile\b" scripts/controllers/gameplay_controller.gd
+```
+
+Expected: all remaining hits have `_` prefix.
+
+Open Godot. F5 — select tiles, verify placement still works.
+
+**Step 5: Commit**
+
+```bash
+git add scripts/controllers/gameplay_controller.gd
+git commit -m "refactor: make GameplayController.interaction_mode and selected_tile private"
+```
+
+---
+
+### Task 7: Remove `DropHandler.last_placement_success` state flag
+
+**Files:**
+- Modify: `scripts/controllers/drop_handler.gd`
+- Modify: `scripts/controllers/gameplay_controller.gd`
+
+**Step 1: Remove the field from `drop_handler.gd`**
+
+```gdscript
+# DELETE lines 17–18:
+## Tracks whether the last drop was successful (read by coordinator).
+var last_placement_success: bool = false
+```
+
+Remove all `last_placement_success = false` and `last_placement_success = true` assignments inside `handle_tile_drop()`. The function already returns `bool` at every exit — that is the source of truth.
+
+Final `handle_tile_drop()` shape (assignments removed, returns unchanged):
+
+```gdscript
+func handle_tile_drop(drop_cell: BoardCell, tiles: Array[Tile]) -> bool:
+	if tiles.is_empty():
+		return false
+
+	var has_board_tiles: bool = _any_tiles_on_board(tiles)
+	var target_cells: Array[BoardCell] = _get_target_cells_for_drop(drop_cell, tiles)
+
+	if target_cells.is_empty():
+		_handle_invalid_drop(tiles, has_board_tiles, drop_cell)
+		return false
+
+	_execute_valid_drop(tiles, target_cells)
+	return true
+```
+
+**Step 2: Update the caller in `gameplay_controller.gd`**
+
+```gdscript
+# BEFORE (lines 263–265):
+	_drop.handle_tile_drop(cell, dragged_tiles)
+	_update_interaction_state()
+	_play.update_play_button_state()
+	_drag_mgr.end_drag(_drop.last_placement_success)
+
+# AFTER:
+	var success := _drop.handle_tile_drop(cell, dragged_tiles)
+	_update_interaction_state()
+	_play.update_play_button_state()
+	_drag_mgr.end_drag(success)
+```
+
+**Step 3: Verify**
+
+```
+grep -rn "last_placement_success" --include="*.gd" .
+```
+
+Expected: zero results.
+
+Open Godot. F5 — drag tiles to valid and invalid cells, confirm placement and cancel animations behave correctly.
+
+**Step 4: Commit**
+
+```bash
+git add scripts/controllers/drop_handler.gd scripts/controllers/gameplay_controller.gd
+git commit -m "refactor: replace DropHandler.last_placement_success flag with return value"
+```
+
+---
+
+## Phase 2 — Complexity Reduction
+
+---
+
+### Task 8: Extract `_categorize_tiles_by_animation()` in PlayHandler
+
+**Files:**
+- Modify: `scripts/controllers/play_handler.gd`
+
+The identical 11-line categorization block appears twice: in `on_play_requested()` (lines 55–62) and `_auto_end_round()` (lines 102–110). Extract it once.
+
+**Step 1: Add the helper method**
+
+Add this anywhere in the private section of `play_handler.gd`:
+
+```gdscript
+## Splits tiles into spin (EXTRA/MULTI/EXPO) and stomp (RESET/plain) groups.
+func _categorize_tiles_by_animation(tiles: Array[Tile]) -> Dictionary:
+	var spin: Array[Tile] = []
+	var stomp: Array[Tile] = []
+	for tile in tiles:
+		if tile.has_modifier(ModifierTypes.Type.RESET):
+			stomp.append(tile)
+		elif tile.has_modifier(ModifierTypes.Type.EXTRA) \
+			or tile.has_modifier(ModifierTypes.Type.MULTI) \
+			or tile.has_modifier(ModifierTypes.Type.EXPO):
+			spin.append(tile)
+		else:
+			stomp.append(tile)
+	return {spin = spin, stomp = stomp}
+```
+
+**Step 2: Replace the first duplicated block in `on_play_requested()`**
+
+```gdscript
+# BEFORE (lines 55–62):
+	var spin_tiles: Array[Tile] = []
+	var stomp_tiles: Array[Tile] = []
+	for tile in all_tiles:
+		if tile.has_modifier(ModifierTypes.Type.RESET):
+			stomp_tiles.append(tile)
+		elif tile.has_modifier(ModifierTypes.Type.EXTRA) \
+			or tile.has_modifier(ModifierTypes.Type.MULTI) \
+			or tile.has_modifier(ModifierTypes.Type.EXPO):
+			spin_tiles.append(tile)
+		else:
+			stomp_tiles.append(tile)
+
+# AFTER:
+	var cats := _categorize_tiles_by_animation(all_tiles)
+	var spin_tiles: Array[Tile] = cats.spin
+	var stomp_tiles: Array[Tile] = cats.stomp
+```
+
+**Step 3: Replace the second duplicated block in `_auto_end_round()`**
+
+```gdscript
+# BEFORE (lines 102–110):
+	var spin_tiles: Array[Tile] = []
+	var stomp_tiles: Array[Tile] = []
+	for tile in all_tiles:
+		if tile.has_modifier(ModifierTypes.Type.RESET):
+			stomp_tiles.append(tile)
+		elif tile.has_modifier(ModifierTypes.Type.EXTRA) \
+			or tile.has_modifier(ModifierTypes.Type.MULTI) \
+			or tile.has_modifier(ModifierTypes.Type.EXPO):
+			spin_tiles.append(tile)
+		else:
+			stomp_tiles.append(tile)
+
+# AFTER:
+	var cats := _categorize_tiles_by_animation(all_tiles)
+	var spin_tiles: Array[Tile] = cats.spin
+	var stomp_tiles: Array[Tile] = cats.stomp
+```
+
+**Step 4: Verify**
+
+Open Godot. F5 — play words with and without modifier tiles. Confirm spin animation fires for EXTRA/MULTI/EXPO tiles and stomp for RESET/plain tiles.
+
+**Step 5: Commit**
+
+```bash
+git add scripts/controllers/play_handler.gd
+git commit -m "refactor: extract _categorize_tiles_by_animation() to eliminate duplication in PlayHandler"
+```
+
+---
+
+### Task 9: Decompose `GameplayController._on_tile_drag_started()`
+
+**Files:**
+- Modify: `scripts/controllers/gameplay_controller.gd`
+
+**Step 1: Add helper `_collect_drag_candidates()`**
+
+```gdscript
+## Builds the list of tiles to drag. Ensures lead tile is always included.
+## Removes followers that refuse drag. Resets selection if lead was not selected.
+func _collect_drag_candidates(tile: Tile) -> Array[Tile]:
+	var candidates: Array[Tile] = []
+	for t in _selection.get_selected_tiles():
+		if t.can_interact():
+			candidates.append(t)
+
+	if tile not in candidates:
+		_selection.deselect_all()
+		_selection.select_tile(tile)
+		return [tile]
+
+	for t in candidates.duplicate():
+		if t != tile and not t.set_as_drag_follower():
+			candidates.erase(t)
+
+	return candidates
+```
+
+**Step 2: Rewrite `_on_tile_drag_started()`**
+
+```gdscript
+func _on_tile_drag_started(tile: Tile) -> void:
+	if not _is_active or not tile.can_interact():
+		return
+
+	var valid_tiles := _collect_drag_candidates(tile)
+	if valid_tiles.is_empty():
+		print("[Gameplay] No valid tiles to drag")
+		return
+
+	_drag_mgr.start_drag(tile, valid_tiles)
+	if valid_tiles.size() > 1:
+		print("[Gameplay] Multi-drag started with %d tiles" % valid_tiles.size())
+```
+
+**Step 3: Verify**
+
+Open Godot. F5 — test single drag, multi-drag, and dragging a locked tile. Confirm behaviour unchanged.
+
+**Step 4: Commit**
+
+```bash
+git add scripts/controllers/gameplay_controller.gd
+git commit -m "refactor: extract _collect_drag_candidates() to decompose _on_tile_drag_started (CC 7→3)"
+```
+
+---
+
+### Task 10: Decompose `GameplayController._on_cell_clicked()`
+
+**Files:**
+- Modify: `scripts/controllers/gameplay_controller.gd`
+
+**Step 1: Add helper `_place_tiles_on_cell()`**
+
+```gdscript
+## Places one or more movable tiles starting at the target cell.
+func _place_tiles_on_cell(movable: Array[Tile], cell: BoardCell) -> void:
+	if movable.size() > 1:
+		var cells: Array[BoardCell] = _placement.get_sequential_cells(cell, movable.size())
+		if cells.is_empty():
+			print("[Gameplay] Cannot place %d tiles starting at %s" % [movable.size(), cell.name])
+			return
+		for i in movable.size():
+			_placement.place_tile_on_cell_silent(movable[i], cells[i])
+		print("[Gameplay] Placed %d tiles starting at %s" % [movable.size(), cell.name])
+	else:
+		_placement.place_tile_on_cell(movable[0], cell)
+	_selection.deselect_all()
+	_update_interaction_state()
+	_play.update_play_button_state()
+	tile_placement_completed.emit(movable[0], cell)
+```
+
+**Step 2: Rewrite `_on_cell_clicked()`**
+
+```gdscript
+func _on_cell_clicked(cell: BoardCell) -> void:
+	if not _is_active:
+		return
+
+	var selected: Array[Tile] = _selection.get_selected_tiles()
+	if selected.is_empty():
+		print("[Gameplay] No tile selected")
+		return
+
+	var movable: Array[Tile] = selected.filter(func(t): return not t.is_locked)
+	if movable.is_empty():
+		print("[Gameplay] All selected tiles are locked")
+		_selection.deselect_all()
+		_update_interaction_state()
+		return
+
+	if cell.is_occupied():
+		print("[Gameplay] Cell occupied: %s" % cell.name)
+		return
+
+	_place_tiles_on_cell(movable, cell)
+```
+
+**Step 3: Verify**
+
+Open Godot. F5 — click-to-place a single tile, click-to-place multiple selected tiles, attempt to place on occupied cell. All should behave identically to before.
+
+**Step 4: Commit**
+
+```bash
+git add scripts/controllers/gameplay_controller.gd
+git commit -m "refactor: extract _place_tiles_on_cell() to decompose _on_cell_clicked (CC 6→4)"
+```
+
+---
+
+### Task 11: Simplify `GameplayController._on_tile_selected()` with match
+
+**Files:**
+- Modify: `scripts/controllers/gameplay_controller.gd`
+
+**Step 1: Rewrite using `match`**
+
+```gdscript
+func _on_tile_selected(tile: Tile) -> void:
+	if not _is_active:
+		return
+
+	print("[Gameplay] Tile selected: %s" % tile.name)
+
+	match tile.location:
+		Tile.TileLocation.ON_BOARD:
+			if _selection.has_selection():
+				print("[Gameplay] Cannot stack tiles")
+			else:
+				print("[Gameplay] Board tile at cell: %s" % tile.current_cell.name)
+		Tile.TileLocation.IN_HAND:
+			_selection.select_tile(tile)
+			_update_interaction_state()
+```
+
+**Step 2: Verify**
+
+Open Godot. F5 — click a hand tile (selects), click a board tile while selection active (prints warning), click a board tile with no selection (prints info). Behaviour unchanged.
+
+**Step 3: Commit**
+
+```bash
+git add scripts/controllers/gameplay_controller.gd
+git commit -m "refactor: use match for tile location dispatch in _on_tile_selected (CC 5→3)"
+```
+
+---
+
+### Task 12: Extract `_check_quality_win_conditions()` from RunManager
+
+**Files:**
+- Modify: `autoload/run_manager.gd`
+
+**Step 1: Add helper**
+
+```gdscript
+## Checks if any quality wants to end the run. Handles the transition if so.
+## Returns true if the run was ended (caller should return early).
+func _check_quality_win_conditions() -> bool:
+	if _active_run == null:
+		return false
+	for quality in _active_run.qualities:
+		if not quality.has_custom_win_condition():
+			continue
+		var result := quality.check_run_end_condition(run_state)
+		if not result.get("should_end", false):
+			continue
+		var victory: bool = result.get("victory", false)
+		run_state.end_run()
+		EventBus.run_ended.emit(victory, run_state.total_score)
+		print("[RunManager] Quality '%s' ended run - Victory: %s" % [quality.get_quality_name(), victory])
+		return true
+	return false
+```
+
+**Step 2: Simplify `_on_round_ended()`**
+
+```gdscript
+func _on_round_ended(round_number: int, success: bool) -> void:
+	if not run_state or not run_state.is_run_active:
+		return
+
+	if _active_run:
+		for quality in _active_run.qualities:
+			quality.on_round_ended(round_number, success)
+
+	if not success:
+		run_state.end_run()
+		EventBus.run_ended.emit(false, run_state.total_score)
+		print("[RunManager] Round %d lost - run ended" % round_number)
+		return
+
+	run_state.complete_round(GameManager.get_current_score())
+	if _check_quality_win_conditions():
+		return
+	EventBus.run_shop_requested.emit(run_state.current_round)
+	print("[RunManager] Round %d won - proceeding to shop" % round_number)
+```
+
+**Step 3: Verify**
+
+Open Godot. F5 — complete a round successfully, lose a round, complete a MaxScoreInNRoundsQuality run. All transitions should behave correctly.
+
+**Step 4: Commit**
+
+```bash
+git add autoload/run_manager.gd
+git commit -m "refactor: extract _check_quality_win_conditions() to decompose _on_round_ended (CC 6→5)"
+```
+
+---
+
+### Task 13: Extract `_pick_weighted()` in RandomModifiersQuality
+
+**Files:**
+- Modify: `scripts/domain/qualities/random_modifiers_quality.gd`
+
+**Step 1: Add generic helper**
+
+```gdscript
+## Picks a random key from a weights dictionary {key: int_weight}.
+func _pick_weighted(weights: Dictionary) -> Variant:
+	var total: int = 0
+	for w in weights.values():
+		total += w
+	var roll: int = randi() % total
+	var cumulative: int = 0
+	for key in weights:
+		cumulative += weights[key]
+		if roll < cumulative:
+			return key
+	return weights.keys()[0]
+```
+
+**Step 2: Replace `_pick_weighted_type()`**
+
+```gdscript
+func _pick_weighted_type() -> ModifierTypes.Type:
+	return _pick_weighted(TYPE_WEIGHTS)
+```
+
+**Step 3: Replace `_pick_weighted_tier()`**
+
+```gdscript
+func _pick_weighted_tier() -> ModifierTypes.Tier:
+	return _pick_weighted(TIER_WEIGHTS)
+```
+
+**Step 4: Verify**
+
+Open Godot. F5 — start a run with Random Modifiers quality, begin a round, confirm modifier tiles appear with the expected distribution (EXTRA most common, RESET rarest).
+
+**Step 5: Commit**
+
+```bash
+git add scripts/domain/qualities/random_modifiers_quality.gd
+git commit -m "refactor: extract _pick_weighted() to eliminate duplication in RandomModifiersQuality (CC 6→2 each)"
+```
+
+---
+
+## Phase 3 — Architecture Patterns
+
+---
+
+### Task 14: Create `SignalTracker` utility class
+
+**Files:**
+- Create: `scripts/util/signal_tracker.gd`
+
+**Step 1: Create the file**
+
+```gdscript
+class_name SignalTracker
+extends RefCounted
+
+## Tracks signal connections and disconnects all at once.
+## Replaces ad-hoc _connections arrays and _safe_connect/_disconnect_all patterns.
+
+var _connections: Array[Dictionary] = []
+
+
+## Connects sig to fn and records the connection for later cleanup.
+func track(sig: Signal, fn: Callable) -> void:
+	sig.connect(fn)
+	_connections.append({s = sig, f = fn})
+
+
+## Disconnects all tracked connections and clears the list.
+func disconnect_all() -> void:
+	for c in _connections:
+		if c.s.is_connected(c.f):
+			c.s.disconnect(c.f)
+	_connections.clear()
+```
+
+**Step 2: Verify**
+
+Open Godot. Check Output — no errors loading the new class.
+
+**Step 3: Commit**
+
+```bash
+git add scripts/util/signal_tracker.gd
+git commit -m "feat: add SignalTracker utility for unified signal lifecycle management"
+```
+
+---
+
+### Task 15: Use `SignalTracker` in `GameplayController`
+
+**Files:**
+- Modify: `scripts/controllers/gameplay_controller.gd`
+
+**Step 1: Replace `_connections` field and helper methods**
+
+```gdscript
+# REMOVE:
+var _connections: Array[Dictionary] = []
+
+# ADD:
+var _tracker: SignalTracker = SignalTracker.new()
+```
+
+Remove the two helper methods entirely:
+```gdscript
+# DELETE:
+func _safe_connect(sig: Signal, handler: Callable) -> void: ...
+func _disconnect_all() -> void: ...
+```
+
+**Step 2: Update `_connect_signals()`**
+
+Replace every `_safe_connect(sig, fn)` call with `_tracker.track(sig, fn)`:
+
+```gdscript
+func _connect_signals() -> void:
+	if board:
+		_tracker.track(board.cell_clicked, _on_cell_clicked)
+		_tracker.track(board.cell_hovered, _on_cell_hovered)
+		_tracker.track(board.cell_unhovered, _on_cell_unhovered)
+
+	if discard_pile:
+		_tracker.track(discard_pile.tiles_dropped, _on_discard_pile_tiles_dropped)
+		_tracker.track(discard_pile.discard_clicked, _on_discard_pile_clicked)
+		_tracker.track(discard_pile.peek_requested, _on_discard_pile_peek_requested)
+
+	if main_hud:
+		_tracker.track(main_hud.draw_requested, _on_draw_requested)
+		_tracker.track(main_hud.play_requested, _on_play_requested)
+
+	_tracker.track(_drag_mgr.drag_release_requested, _handle_drag_release)
+	_tracker.track(EventBus.hand_count_changed, _on_tile_supply_changed)
+	_tracker.track(EventBus.bag_count_changed, _on_tile_supply_changed)
+```
+
+**Step 3: Update `deactivate()`**
+
+```gdscript
+# BEFORE:
+	_disconnect_all()
+
+# AFTER:
+	_tracker.disconnect_all()
+```
+
+**Step 4: Verify**
+
+Open Godot. F5 — activate gameplay, deactivate (go to title screen), reactivate. Signals should connect/disconnect cleanly with no double-fire or missing events.
+
+**Step 5: Commit**
+
+```bash
+git add scripts/controllers/gameplay_controller.gd
+git commit -m "refactor: replace _safe_connect/_disconnect_all with SignalTracker in GameplayController"
+```
+
+---
+
+### Task 16: Use `SignalTracker` in `RunManager`
+
+**Files:**
+- Modify: `autoload/run_manager.gd`
+
+**Step 1: Find the quality connections infrastructure**
+
+```
+grep -n "_quality_connections\|_connect_quality_signals\|_disconnect_quality_signals" autoload/run_manager.gd
+```
+
+Note the line numbers.
+
+**Step 2: Replace `_quality_connections` field**
+
+```gdscript
+# REMOVE:
+var _quality_connections: Array[Dictionary] = []
+
+# ADD:
+var _quality_tracker: SignalTracker = SignalTracker.new()
+```
+
+**Step 3: Rewrite `_connect_quality_signals()`**
+
+Find the existing method. Replace all `_quality_connections.append(...)` patterns with `_quality_tracker.track(sig, fn)`.
+
+The structure should be:
+```gdscript
+func _connect_quality_signals() -> void:
+	if _active_run == null:
+		return
+	for quality in _active_run.qualities:
+		if quality.has_method("on_process"):
+			# on_process is called directly, no signal needed
+			pass
+		var expired_cb := func(): _on_quality_time_expired()
+		_quality_tracker.track(quality.time_expired, expired_cb)
+		# add any other quality signal connections here
+```
+
+Adapt this to whatever signals the existing `_connect_quality_signals()` actually connects. The key change is `_quality_tracker.track(...)` instead of `_quality_connections.append(...)`.
+
+**Step 4: Rewrite `_disconnect_quality_signals()`**
+
+```gdscript
+func _disconnect_quality_signals() -> void:
+	_quality_tracker.disconnect_all()
+```
+
+**Step 5: Verify**
+
+Open Godot. F5 — start a run with Time Attack quality, complete a round. Timer should stop between rounds (signals disconnected and reconnected cleanly).
+
+**Step 6: Commit**
+
+```bash
+git add autoload/run_manager.gd
+git commit -m "refactor: replace _quality_connections with SignalTracker in RunManager"
+```
+
+---
+
+### Task 17: Create `TimerQuality` base class
+
+**Files:**
+- Create: `scripts/domain/qualities/timer_quality.gd`
+
+**Step 1: Create the file**
+
+```gdscript
+class_name TimerQuality
+extends RunQuality
+
+## Base class for RunQuality types that implement a countdown timer.
+## Subclasses set _time_remaining and _is_active in on_round_started().
+## The shared countdown + emission logic lives here.
+
+var _time_remaining: float = 0.0
+var _is_active: bool = false
+
+
+func has_timer() -> bool:
+	return true
+
+
+func on_round_ended(_round_number: int, _success: bool) -> void:
+	_is_active = false
+
+
+func on_process(delta: float) -> void:
+	if not _is_active:
+		return
+	_time_remaining = maxf(0.0, _time_remaining - delta)
+	time_updated.emit(_time_remaining)
+	if _time_remaining <= 0.0:
+		_is_active = false
+		time_expired.emit()
+```
+
+**Step 2: Verify**
+
+Open Godot. Expected: no errors loading the class (it has no scene).
+
+**Step 3: Commit**
+
+```bash
+git add scripts/domain/qualities/timer_quality.gd
+git commit -m "feat: add TimerQuality base class with shared countdown logic"
+```
+
+---
+
+### Task 18: Make `TimeAttackQuality` extend `TimerQuality`
+
+**Files:**
+- Modify: `scripts/domain/qualities/time_attack_quality.gd`
+
+**Step 1: Rewrite the file**
+
+```gdscript
+extends TimerQuality
+class_name TimeAttackQuality
+
+## TimeAttackQuality: Each round has a fixed countdown timer.
+## When time expires, the round is lost.
+
+const DEFAULT_TIME: float = 120.0
+
+
+func get_quality_id() -> StringName:
+	return &"time_attack"
+
+func get_quality_name() -> String:
+	return "Time Attack"
+
+func get_description() -> String:
+	return "Each round has a %d second time limit." % int(DEFAULT_TIME)
+
+
+func on_round_started(_round_number: int) -> void:
+	_time_remaining = DEFAULT_TIME
+	_is_active = true
+
+
+func to_dict() -> Dictionary:
+	return {"quality_id": get_quality_id(), "default_time": DEFAULT_TIME}
+```
+
+Removed: `_time_remaining`, `_is_active` fields, `has_timer()`, `on_round_ended()`, `on_process()` — all inherited from `TimerQuality`.
+
+**Step 2: Verify**
+
+Open Godot. F5 — start a Time Attack run. Timer should count down, expire, and end the round on timeout.
+
+**Step 3: Commit**
+
+```bash
+git add scripts/domain/qualities/time_attack_quality.gd
+git commit -m "refactor: TimeAttackQuality extends TimerQuality (removes 15 lines of duplicated logic)"
+```
+
+---
+
+### Task 19: Make `LimitedTimeWithIncrementQuality` extend `TimerQuality`
+
+**Files:**
+- Modify: `scripts/domain/qualities/limited_time_with_increment_quality.gd`
+
+**Step 1: Rewrite the file**
+
+```gdscript
+extends TimerQuality
+class_name LimitedTimeWithIncrementQuality
+
+## LimitedTimeWithIncrementQuality: Countdown timer that adds time on each play.
+
+const DEFAULT_TIME: float = 60.0
+const INCREMENT_PER_PLAY: float = 15.0
+
+
+func get_quality_id() -> StringName:
+	return &"limited_time_with_increment"
+
+func get_quality_name() -> String:
+	return "Time + Increment"
+
+func get_description() -> String:
+	return "%ds per round, +%ds per play." % [int(DEFAULT_TIME), int(INCREMENT_PER_PLAY)]
+
+
+func on_round_started(_round_number: int) -> void:
+	_time_remaining = DEFAULT_TIME
+	_is_active = true
+
+
+func on_play_completed(_plays_remaining: int) -> void:
+	if _is_active:
+		_time_remaining += INCREMENT_PER_PLAY
+		time_incremented.emit(INCREMENT_PER_PLAY)
+		time_updated.emit(_time_remaining)
+
+
+func to_dict() -> Dictionary:
+	return {
+		"quality_id": get_quality_id(),
+		"default_time": DEFAULT_TIME,
+		"increment": INCREMENT_PER_PLAY,
+	}
+```
+
+Removed: `_time_remaining`, `_is_active`, `has_timer()`, `on_round_ended()`, `on_process()` — all inherited.
+
+**Step 2: Verify**
+
+Open Godot. F5 — start a Limited Time + Increment run. Timer counts down, each successful play adds 15s, expiry ends the round.
+
+**Step 3: Commit**
+
+```bash
+git add scripts/domain/qualities/limited_time_with_increment_quality.gd
+git commit -m "refactor: LimitedTimeWithIncrementQuality extends TimerQuality (removes 15 lines of duplicated logic)"
+```
+
+---
+
+### Task 20: Decouple `PlayHandler` from `MainHUD` via signals
+
+**Files:**
+- Modify: `scripts/controllers/play_handler.gd`
+- Modify: `scripts/controllers/gameplay_controller.gd`
+
+**Step 1: Add signals and remove `main_hud` from `play_handler.gd`**
+
+In the signals section, add:
+```gdscript
+signal draw_blocked_changed(blocked: bool)
+signal play_button_changed(enabled: bool, end_round_mode: bool)
+```
+
+Remove the `main_hud` field:
+```gdscript
+# DELETE:
+var main_hud: CanvasLayer = null
+```
+
+Update `setup()` — remove `p_hud` parameter:
+```gdscript
+# BEFORE:
+func setup(p_board: Board, p_hud: CanvasLayer, p_selection: SelectionManager) -> void:
+	board = p_board
+	main_hud = p_hud
+	_selection = p_selection
+	_word_validator = WordValidator.new()
+
+# AFTER:
+func setup(p_board: Board, p_selection: SelectionManager) -> void:
+	board = p_board
+	_selection = p_selection
+	_word_validator = WordValidator.new()
+```
+
+**Step 2: Replace all `main_hud` calls with signal emissions**
+
+In `on_play_requested()`:
+```gdscript
+# BEFORE:
+	main_hud.set_draw_button_blocked(true)
+# AFTER:
+	draw_blocked_changed.emit(true)
+
+# BEFORE:
+	main_hud.set_draw_button_blocked(false)
+# AFTER:
+	draw_blocked_changed.emit(false)
+```
+
+In `_auto_end_round()`:
+```gdscript
+# BEFORE:
+	main_hud.set_play_button_enabled(false)
+# AFTER:
+	play_button_changed.emit(false, false)
+```
+
+In `update_play_button_state()`:
+```gdscript
+# BEFORE:
+func update_play_button_state() -> void:
+	if not main_hud:
+		return
+	var has_unplayed_tiles: bool = not _get_unplayed_board_tiles().is_empty()
+	if has_unplayed_tiles:
+		main_hud.set_play_button_enabled(true)
+		main_hud.set_play_button_mode(false)
+	elif not has_valid_moves() and GameManager.get_plays_remaining() > 0:
+		main_hud.set_play_button_enabled(true)
+		main_hud.set_play_button_mode(true)
+	else:
+		main_hud.set_play_button_enabled(false)
+		main_hud.set_play_button_mode(false)
+
+# AFTER:
+func update_play_button_state() -> void:
+	var has_unplayed: bool = not _get_unplayed_board_tiles().is_empty()
+	if has_unplayed:
+		play_button_changed.emit(true, false)
+	elif not has_valid_moves() and GameManager.get_plays_remaining() > 0:
+		play_button_changed.emit(true, true)
+	else:
+		play_button_changed.emit(false, false)
+```
+
+**Step 3: Update `GameplayController.setup()` to wire the new signals**
+
+```gdscript
+# BEFORE:
+	_play = PlayHandler.new()
+	_play.setup(board, main_hud, _selection)
+	_play.play_completed.connect(func(tiles, words): play_completed.emit(tiles, words))
+
+# AFTER:
+	_play = PlayHandler.new()
+	_play.setup(board, _selection)
+	_play.play_completed.connect(func(tiles, words): play_completed.emit(tiles, words))
+	_play.draw_blocked_changed.connect(
+		func(blocked): main_hud.set_draw_button_blocked(blocked)
+	)
+	_play.play_button_changed.connect(
+		func(enabled, mode):
+			main_hud.set_play_button_enabled(enabled)
+			main_hud.set_play_button_mode(mode)
+	)
+```
+
+**Step 4: Verify**
+
+```
+grep -n "main_hud" scripts/controllers/play_handler.gd
+```
+
+Expected: zero results.
+
+Open Godot. F5 — play tiles: draw button should block during animation and unblock after. Play button should enable when tiles are on board and switch to End Round mode when no valid moves remain.
+
+**Step 5: Commit**
+
+```bash
+git add scripts/controllers/play_handler.gd scripts/controllers/gameplay_controller.gd
+git commit -m "refactor: decouple PlayHandler from MainHUD via draw_blocked_changed and play_button_changed signals"
+```
+
+---
+
+### Task 21: Collapse `TileAnimator._ensure_*_resources()` duplication
+
+**Files:**
+- Modify: `autoload/tile_animator.gd`
+
+**Step 1: Add two generic helpers**
+
+```gdscript
+## Lazy-initializes a strategy (no constructor args).
+func _ensure_strategy(current: Variant, klass: GDScript) -> Variant:
+	return current if current != null else klass.new()
+
+## Lazy-initializes an executor (takes _context as constructor arg).
+func _ensure_executor(current: Variant, klass: GDScript) -> Variant:
+	return current if current != null else klass.new(_context)
+```
+
+**Step 2: Replace all five `_ensure_*_resources()` methods**
+
+```gdscript
+func _ensure_draw_resources() -> void:
+	_draw_animation = _ensure_strategy(_draw_animation, DrawTileAnimation)
+	_batch_executor = _ensure_executor(_batch_executor, BatchAnimationExecutor)
+
+func _ensure_glide_resources() -> void:
+	_glide_animation = _ensure_strategy(_glide_animation, GlideTileAnimation)
+	_return_executor = _ensure_executor(_return_executor, ReturnAnimationExecutor)
+
+func _ensure_shake_resources() -> void:
+	_shake_animation = _ensure_strategy(_shake_animation, ShakeTileAnimation)
+	_shake_executor = _ensure_executor(_shake_executor, ShakeAnimationExecutor)
+
+func _ensure_stomp_resources() -> void:
+	_stomp_animation = _ensure_strategy(_stomp_animation, StompTileAnimation)
+	_stomp_executor = _ensure_executor(_stomp_executor, StompAnimationExecutor)
+
+func _ensure_spin_resources() -> void:
+	_spin_animation = _ensure_strategy(_spin_animation, SpinTileAnimation)
+	_spin_executor = _ensure_executor(_spin_executor, SpinAnimationExecutor)
+```
+
+**Step 3: Verify**
+
+Open Godot. F5 — draw tiles (batch), play tiles (stomp + spin), shake on invalid action, discard tiles. All animations should work correctly.
+
+**Step 4: Commit**
+
+```bash
+git add autoload/tile_animator.gd
+git commit -m "refactor: collapse TileAnimator lazy-loaders into _ensure_strategy/_ensure_executor helpers"
+```
+
+---
+
+## Final Verification
+
+After all tasks are complete:
+
+**1. Check for lingering dead symbols:**
+```
+grep -rn "point_modifier\|is_wild\|start_alpha\|last_placement_success\|available_tiles\b\|drawn_tiles\b\|discard_pile\b" --include="*.gd" .
+```
+Expected: zero results (these were all removed or renamed).
+
+**2. Check cyclomatic complexity hotspots are gone:**
+```
+grep -n "def \|func " scripts/controllers/play_handler.gd scripts/controllers/gameplay_controller.gd autoload/run_manager.gd
+```
+Manually verify the key functions above have been replaced.
+
+**3. Full play session:**
+- Start a Standard run — normal gameplay, play tiles, score, advance rounds
+- Start a Cursed run — all tiles show RESET, stomp animation only
+- Start a Time Attack run — timer counts down and expires
+- Start a Limited Time + Increment run — +15s per play
+- Start a Random Modifiers run — tiles get random modifiers each round

--- a/docs/plans/2026-02-21-decks-design.md
+++ b/docs/plans/2026-02-21-decks-design.md
@@ -1,0 +1,188 @@
+# Decks Feature Design
+
+**Date**: 2026-02-21
+**Status**: Approved
+
+---
+
+## Overview
+
+Add a first-class `Deck` domain concept to Wordatro. A deck defines the tile pool (letter
+distribution) and may bundle a `RunQuality` that modifies tile state each round. Players
+select a deck in the Run Setup popup before starting a run.
+
+Three built-in decks ship with this feature:
+
+| Deck | Distribution | Bundled Quality |
+|------|-------------|-----------------|
+| Standard | `bag_default.tres` — 98 tiles, Scrabble frequencies | none |
+| Equal | `bag_equal.tres` — 26 tiles, 1 of each letter | none |
+| Cursed | `bag_default.tres` — familiar frequencies | `AllResetQuality` (all tiles carry RESET each round) |
+
+---
+
+## Design Principles
+
+- OOP + DDD: `DeckDefinition` is a domain value object, not a scene node.
+- Spec-Driven: every public method carries behavioural contracts as doc comments.
+- Cyclomatic complexity ≤ 5; decompose any method that exceeds it.
+- High-frequency, low-verbosity patterns: follow `RunQuality` / `QualityRegistry` exactly.
+
+---
+
+## Domain Model (`scripts/domain/decks/`)
+
+### `DeckDefinition extends RefCounted`
+
+Abstract base class. Mirrors `RunQuality` structure.
+
+```gdscript
+## Precondition : get_id() returns a non-empty, unique StringName.
+## Precondition : create_distribution() returns a valid BagDistribution (is_valid() == true).
+## Invariant    : create_bundled_quality() returns null or a valid RunQuality instance.
+
+func get_id() -> StringName
+func get_display_name() -> String
+func get_description() -> String
+func create_distribution() -> BagDistribution
+func create_bundled_quality() -> RunQuality   # default: return null
+```
+
+### Concrete Decks
+
+**`StandardDeck extends DeckDefinition`**
+- `get_id()` → `&"standard"`
+- `create_distribution()` → loads `res://Data/BagDistribution/bag_default.tres`
+- `create_bundled_quality()` → `null`
+
+**`EqualDeck extends DeckDefinition`**
+- `get_id()` → `&"equal"`
+- `create_distribution()` → loads `res://Data/BagDistribution/bag_equal.tres`
+- `create_bundled_quality()` → `null`
+
+**`CursedDeck extends DeckDefinition`**
+- `get_id()` → `&"cursed"`
+- `create_distribution()` → loads `res://Data/BagDistribution/bag_default.tres`
+- `create_bundled_quality()` → `AllResetQuality.new()`
+
+### `DeckRegistry extends RefCounted`
+
+Static factory. Identical pattern to `QualityRegistry`.
+
+```gdscript
+## Precondition : _factories populated with standard, equal, cursed on first access.
+## Postcondition: create_default(unknown_id) returns null and logs a warning.
+## Invariant    : all registered IDs are unique StringNames.
+
+static func register(id: StringName, factory: Callable) -> void
+static func create_default(id: StringName) -> DeckDefinition
+static func get_all_deck_ids() -> Array[StringName]
+```
+
+---
+
+## New Quality (`scripts/domain/qualities/`)
+
+### `AllResetQuality extends RunQuality`
+
+Applied each round to all tiles currently in the bag.
+
+```gdscript
+## get_quality_id() → &"all_reset"
+## NOT registered in QualityRegistry (deck-bundled only; hidden from UI quality list).
+##
+## on_round_started:
+##   Precondition : TileBag.available_tiles is populated.
+##   Postcondition: every tile in TileBag.available_tiles carries a RESET / PER_ROUND modifier.
+##   Invariant    : tile.add_modifier() replaces existing RESET by type — no duplicates.
+```
+
+---
+
+## New Data File
+
+**`Data/BagDistribution/bag_equal.tres`**
+- Type: `BagDistribution`
+- Distribution: all 26 letters (A–Z), count = 1 each (26 tiles total).
+
+---
+
+## RunBuilder Integration (`scripts/domain/run_builder.gd`)
+
+Add `set_deck()` alongside the existing `set_bag()`.
+
+```gdscript
+## set_deck(deck):
+##   Postcondition: build() sets run.bag_config = deck.create_distribution().
+##   Postcondition: if deck.create_bundled_quality() != null, quality is added to run.qualities.
+##   Invariant    : deck takes precedence over set_bag() when both are called.
+##   Invariant    : bundled quality obeys existing duplicate-guard in add_quality().
+##
+## set_bag() is kept unchanged for the legacy initialize_run() path.
+```
+
+Build priority: `_deck` → `_bag_config` → default `bag_default.tres`.
+
+---
+
+## RunSetupPopup Rework (`scenes/title_screen/run_setup_popup.gd`)
+
+Add a **Deck section** above the existing quality list. No new scene file needed — add
+nodes dynamically in `_ready()` the same way quality checkboxes are built today.
+
+### New Layout
+
+```
+RunSetupPopup (Panel)
+└── VBoxContainer
+    ├── [NEW] Deck Section (VBoxContainer)
+    │   ├── Label  "Deck"
+    │   ├── OptionButton  (one item per DeckRegistry entry)
+    │   └── Label  deck description — updates on selection change
+    ├── [NEW] HSeparator
+    ├── [existing] Label  "Modifiers"
+    ├── [existing] ScrollContainer → QualityList
+    └── [existing] ButtonContainer  (Start / Back)
+```
+
+### Behaviour Specs
+
+```
+## Spec: _populate_deck_selector() fills OptionButton from DeckRegistry.get_all_deck_ids().
+## Spec: default selected index corresponds to &"standard".
+## Spec: on OptionButton.item_selected → description label updates immediately.
+## Spec: _build_run() calls builder.set_deck(_get_selected_deck()).
+## Spec: Start with Standard → run.bag_config == bag_default.tres distribution.
+## Spec: Start with CursedDeck → AllResetQuality present in run.qualities.
+```
+
+---
+
+## File Map
+
+### New Files
+
+| Path | Purpose |
+|------|---------|
+| `scripts/domain/decks/deck_definition.gd` | Abstract base `DeckDefinition` |
+| `scripts/domain/decks/standard_deck.gd` | StandardDeck |
+| `scripts/domain/decks/equal_deck.gd` | EqualDeck |
+| `scripts/domain/decks/cursed_deck.gd` | CursedDeck |
+| `scripts/domain/decks/deck_registry.gd` | Static factory registry |
+| `scripts/domain/qualities/all_reset_quality.gd` | AllResetQuality |
+| `Data/BagDistribution/bag_equal.tres` | Equal distribution (26 × 1) |
+
+### Modified Files
+
+| Path | Change |
+|------|--------|
+| `scripts/domain/run_builder.gd` | Add `set_deck()`, update `build()` priority |
+| `scenes/title_screen/run_setup_popup.gd` | Add deck selector section |
+
+---
+
+## Out of Scope
+
+- Saving/loading selected deck between sessions (future: save system).
+- Animated deck preview or card-flip UI (future: UI polish phase).
+- Deck unlocking / progression gates (future: meta-progression phase).

--- a/docs/plans/2026-02-21-decks-plan.md
+++ b/docs/plans/2026-02-21-decks-plan.md
@@ -1,0 +1,674 @@
+# Decks Feature Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a `DeckDefinition` domain abstraction so players can choose a tile deck (Standard, Equal, Cursed) before starting a run, with the selection wired through `RunBuilder` and surfaced in the Run Setup popup.
+
+**Architecture:** `DeckDefinition extends RefCounted` is an abstract value object with virtual factory methods; three concrete subclasses cover the built-in decks. `DeckRegistry` follows the exact `QualityRegistry` pattern. `RunBuilder.set_deck()` replaces the hardcoded `set_bag()` call in the popup. The popup gains a dynamic deck-selector section built identically to how quality checkboxes are built today.
+
+**Tech Stack:** GDScript 4, Godot 4.5.1, no external dependencies. Specs are behavioral contracts in doc comments (no test runner). Verify each task by launching the game (`F5`) and checking the expected UI/behaviour.
+
+---
+
+## Reference: Key Existing Files
+
+Before starting, skim these files once so the patterns are fresh:
+
+- `scripts/domain/run_quality.gd` — abstract base pattern to mirror for `DeckDefinition`
+- `scripts/domain/qualities/quality_registry.gd` — exact registry pattern to copy
+- `scripts/domain/qualities/random_modifiers_quality.gd` — `TileBag.available_tiles` + `ModifierRegistry.create_modifier()` usage
+- `scripts/domain/run_builder.gd` — where `set_bag()` lives; `build()` priority logic
+- `scenes/title_screen/run_setup_popup.gd` — dynamic UI construction to mirror for deck section
+- `Data/BagDistribution/bag_default.tres` — `.tres` format to copy for `bag_equal.tres`
+
+---
+
+## Task 1: Create `bag_equal.tres`
+
+**Files:**
+- Create: `Data/BagDistribution/bag_equal.tres`
+
+**Step 1: Write the spec contract (in a comment at the top of the file)**
+
+The `.tres` format is plain text. The spec is: distribution must contain exactly the 26 letters A–Z, each with count 1. `is_valid()` must return `true`.
+
+**Step 2: Create the file**
+
+```
+[gd_resource type="Resource" script_class="BagDistribution" load_steps=2 format=3 uid="uid://bag_equal_deck_1"]
+
+[ext_resource type="Script" uid="uid://dmo2awwrmb1jw" path="res://Data/BagDistribution/bag_distribution.gd" id="1_q047y"]
+
+[resource]
+script = ExtResource("1_q047y")
+distribution = {
+"A": 1,
+"B": 1,
+"C": 1,
+"D": 1,
+"E": 1,
+"F": 1,
+"G": 1,
+"H": 1,
+"I": 1,
+"J": 1,
+"K": 1,
+"L": 1,
+"M": 1,
+"N": 1,
+"O": 1,
+"P": 1,
+"Q": 1,
+"R": 1,
+"S": 1,
+"T": 1,
+"U": 1,
+"V": 1,
+"W": 1,
+"X": 1,
+"Y": 1,
+"Z": 1
+}
+metadata/_custom_type_script = "uid://dmo2awwrmb1jw"
+```
+
+> **Note:** The `uid` value `uid://bag_equal_deck_1` is a placeholder. Godot will regenerate a proper UID the first time it imports the file. That is expected — do not manually fix it.
+
+**Step 3: Verify**
+
+Launch the game (`F5`). The project must load without errors in the Output panel. No crash on startup = pass.
+
+**Step 4: Commit**
+
+```bash
+git add Data/BagDistribution/bag_equal.tres
+git commit -m "feat: add equal bag distribution (26 tiles, 1 per letter)"
+```
+
+---
+
+## Task 2: Create `DeckDefinition` abstract base
+
+**Files:**
+- Create: `scripts/domain/decks/deck_definition.gd`
+
+**Step 1: Write the spec contracts first, then implement**
+
+The contracts go in the doc comment block at the top of the file:
+
+```
+## Precondition : get_id() returns a non-empty, unique StringName.
+## Precondition : create_distribution() returns a non-null BagDistribution where is_valid() == true.
+## Invariant    : create_bundled_quality() returns null or a valid RunQuality instance.
+## Invariant    : all methods are pure (no side-effects, no global state).
+```
+
+**Step 2: Implement**
+
+```gdscript
+extends RefCounted
+class_name DeckDefinition
+
+## DeckDefinition: Abstract base for player-selectable tile decks.
+## A deck defines the tile pool (via create_distribution()) and may bundle
+## a RunQuality that modifies tile state each round (via create_bundled_quality()).
+##
+## Precondition : get_id() returns a non-empty, unique StringName.
+## Precondition : create_distribution() returns a non-null BagDistribution where is_valid() == true.
+## Invariant    : create_bundled_quality() returns null or a valid RunQuality instance.
+## Invariant    : all methods are pure (no side-effects, no global state).
+
+# =============================================================================
+# IDENTITY  (override in subclasses)
+# =============================================================================
+
+func get_id() -> StringName:
+	return &""
+
+
+func get_display_name() -> String:
+	return ""
+
+
+func get_description() -> String:
+	return ""
+
+# =============================================================================
+# FACTORY  (override in subclasses)
+# =============================================================================
+
+## Returns the tile distribution for this deck.
+## Postcondition: result != null and result.is_valid() == true.
+func create_distribution() -> BagDistribution:
+	return null
+
+
+## Returns a RunQuality to auto-bundle with the run, or null if none.
+func create_bundled_quality() -> RunQuality:
+	return null
+```
+
+**Step 3: Verify**
+
+Launch game (`F5`). No errors in Output panel. Pass.
+
+**Step 4: Commit**
+
+```bash
+git add scripts/domain/decks/deck_definition.gd
+git commit -m "feat: add DeckDefinition abstract base class"
+```
+
+---
+
+## Task 3: Create `StandardDeck` and `EqualDeck`
+
+**Files:**
+- Create: `scripts/domain/decks/standard_deck.gd`
+- Create: `scripts/domain/decks/equal_deck.gd`
+
+**Step 1: Implement `StandardDeck`**
+
+```gdscript
+extends DeckDefinition
+class_name StandardDeck
+
+## StandardDeck: Scrabble-style distribution (98 tiles, frequency-weighted).
+## No bundled quality.
+##
+## Postcondition: create_distribution() loads bag_default.tres successfully.
+
+func get_id() -> StringName:
+	return &"standard"
+
+
+func get_display_name() -> String:
+	return "Standard"
+
+
+func get_description() -> String:
+	return "Classic Scrabble-style distribution. Common letters appear more often."
+
+
+func create_distribution() -> BagDistribution:
+	return load("res://Data/BagDistribution/bag_default.tres") as BagDistribution
+```
+
+**Step 2: Implement `EqualDeck`**
+
+```gdscript
+extends DeckDefinition
+class_name EqualDeck
+
+## EqualDeck: One of each letter (26 tiles total).
+## No bundled quality.
+##
+## Postcondition: create_distribution() loads bag_equal.tres successfully.
+
+func get_id() -> StringName:
+	return &"equal"
+
+
+func get_display_name() -> String:
+	return "Equal"
+
+
+func get_description() -> String:
+	return "One of every letter. Each tile is equally likely — plan your words carefully."
+
+
+func create_distribution() -> BagDistribution:
+	return load("res://Data/BagDistribution/bag_equal.tres") as BagDistribution
+```
+
+**Step 3: Verify**
+
+Launch game (`F5`). No errors. Pass.
+
+**Step 4: Commit**
+
+```bash
+git add scripts/domain/decks/standard_deck.gd scripts/domain/decks/equal_deck.gd
+git commit -m "feat: add StandardDeck and EqualDeck concrete decks"
+```
+
+---
+
+## Task 4: Create `AllResetQuality`
+
+**Files:**
+- Create: `scripts/domain/qualities/all_reset_quality.gd`
+
+**Step 1: Understand the pattern**
+
+`RandomModifiersQuality.on_round_started()` iterates `TileBag.available_tiles` and calls `tile.add_modifier(ModifierRegistry.create_modifier(type, tier, lifetime))`. `AllResetQuality` does the same but deterministically: every tile gets `RESET / BRONZE / PER_ROUND`.
+
+`tile.add_modifier()` replaces existing modifier by type — no duplicates possible (existing invariant).
+
+**Step 2: Implement**
+
+```gdscript
+extends RunQuality
+class_name AllResetQuality
+
+## AllResetQuality: Applies RESET/PER_ROUND modifier to every bag tile at round start.
+## Bundled by CursedDeck; NOT registered in QualityRegistry (not shown in UI quality list).
+##
+## on_round_started:
+##   Precondition : TileBag.available_tiles is populated.
+##   Postcondition: every tile in TileBag.available_tiles carries a RESET/PER_ROUND modifier.
+##   Invariant    : tile.add_modifier() replaces by type — no duplicates possible.
+
+# =============================================================================
+# IDENTITY
+# =============================================================================
+
+func get_quality_id() -> StringName:
+	return &"all_reset"
+
+
+func get_quality_name() -> String:
+	return "Cursed Tiles"
+
+
+func get_description() -> String:
+	return "All tiles carry the Reset modifier each round."
+
+# =============================================================================
+# LIFECYCLE
+# =============================================================================
+
+func on_round_started(_round_number: int) -> void:
+	_apply_reset_to_all_bag_tiles()
+
+
+# =============================================================================
+# PRIVATE
+# =============================================================================
+
+func _apply_reset_to_all_bag_tiles() -> void:
+	for tile in TileBag.available_tiles:
+		var modifier: ModifierInstance = ModifierRegistry.create_modifier(
+			ModifierTypes.Type.RESET,
+			ModifierTypes.Tier.BRONZE,
+			ModifierTypes.Lifetime.PER_ROUND
+		)
+		tile.add_modifier(modifier)
+	print("[AllResetQuality] Applied RESET to %d bag tiles" % TileBag.available_tiles.size())
+```
+
+**Step 3: Verify**
+
+Launch game (`F5`). No errors. Pass.
+
+**Step 4: Commit**
+
+```bash
+git add scripts/domain/qualities/all_reset_quality.gd
+git commit -m "feat: add AllResetQuality (applies RESET to all bag tiles each round)"
+```
+
+---
+
+## Task 5: Create `CursedDeck`
+
+**Files:**
+- Create: `scripts/domain/decks/cursed_deck.gd`
+
+**Step 1: Implement**
+
+```gdscript
+extends DeckDefinition
+class_name CursedDeck
+
+## CursedDeck: Standard distribution with AllResetQuality bundled.
+## Every tile drawn will carry the RESET modifier each round.
+##
+## Postcondition: create_distribution() returns bag_default.tres distribution.
+## Postcondition: create_bundled_quality() returns a valid AllResetQuality instance.
+
+func get_id() -> StringName:
+	return &"cursed"
+
+
+func get_display_name() -> String:
+	return "Cursed"
+
+
+func get_description() -> String:
+	return "Familiar letters, dark magic. All tiles carry the Reset modifier every round."
+
+
+func create_distribution() -> BagDistribution:
+	return load("res://Data/BagDistribution/bag_default.tres") as BagDistribution
+
+
+func create_bundled_quality() -> RunQuality:
+	return AllResetQuality.new()
+```
+
+**Step 2: Verify**
+
+Launch game (`F5`). No errors. Pass.
+
+**Step 3: Commit**
+
+```bash
+git add scripts/domain/decks/cursed_deck.gd
+git commit -m "feat: add CursedDeck (bundles AllResetQuality)"
+```
+
+---
+
+## Task 6: Create `DeckRegistry`
+
+**Files:**
+- Create: `scripts/domain/decks/deck_registry.gd`
+
+**Step 1: Understand the pattern**
+
+Copy the structure of `scripts/domain/qualities/quality_registry.gd` exactly:
+- `static var _factories: Dictionary`
+- `static var _initialized: bool`
+- `_ensure_initialized()` registers all built-in decks
+- `create_default(id)` / `get_all_deck_ids()` public API
+
+**Step 2: Implement**
+
+```gdscript
+extends RefCounted
+class_name DeckRegistry
+
+## DeckRegistry: Static factory registry for DeckDefinition types.
+## Mirrors QualityRegistry. Maps deck IDs to factory callables.
+##
+## Precondition : _factories populated with standard, equal, cursed on first access.
+## Postcondition: create_default(unknown_id) returns null and logs a warning.
+## Invariant    : all registered IDs are unique StringNames.
+
+# =============================================================================
+# REGISTRY STATE
+# =============================================================================
+
+static var _factories: Dictionary = {}
+static var _initialized: bool = false
+
+# =============================================================================
+# PUBLIC API
+# =============================================================================
+
+static func register(id: StringName, factory: Callable) -> void:
+	_ensure_initialized()
+	_factories[id] = factory
+
+
+static func create_default(id: StringName) -> DeckDefinition:
+	_ensure_initialized()
+	if not _factories.has(id):
+		push_warning("[DeckRegistry] Unknown deck ID: %s" % id)
+		return null
+	return _factories[id].call()
+
+
+static func get_all_deck_ids() -> Array[StringName]:
+	_ensure_initialized()
+	var ids: Array[StringName] = []
+	for key in _factories.keys():
+		ids.append(key)
+	return ids
+
+# =============================================================================
+# INITIALIZATION
+# =============================================================================
+
+static func _ensure_initialized() -> void:
+	if _initialized:
+		return
+	_initialized = true
+
+	_factories[&"standard"] = func() -> DeckDefinition: return StandardDeck.new()
+	_factories[&"equal"]    = func() -> DeckDefinition: return EqualDeck.new()
+	_factories[&"cursed"]   = func() -> DeckDefinition: return CursedDeck.new()
+```
+
+**Step 3: Verify**
+
+Launch game (`F5`). No errors. Pass.
+
+**Step 4: Commit**
+
+```bash
+git add scripts/domain/decks/deck_registry.gd
+git commit -m "feat: add DeckRegistry static factory (standard, equal, cursed)"
+```
+
+---
+
+## Task 7: Update `RunBuilder` — add `set_deck()`
+
+**Files:**
+- Modify: `scripts/domain/run_builder.gd`
+
+**Step 1: Read the current file first**
+
+Open `scripts/domain/run_builder.gd`. Current state:
+- `var _bag_config: BagDistribution = null`
+- `func set_bag(bag: BagDistribution) -> RunBuilder`
+- `build()` uses `_bag_config` with fallback to `bag_default.tres`
+
+**Step 2: Add `_deck` field and `set_deck()` method**
+
+Add after line `var _bag_config: BagDistribution = null`:
+
+```gdscript
+var _deck: DeckDefinition = null
+```
+
+Add after the existing `set_bag()` method:
+
+```gdscript
+## set_deck: Selects a deck for this run.
+## Postcondition: build() uses deck.create_distribution() as bag_config.
+## Postcondition: if deck.create_bundled_quality() != null, quality is added to run.qualities.
+## Invariant    : deck takes precedence over set_bag() when both are called.
+func set_deck(deck: DeckDefinition) -> RunBuilder:
+	_deck = deck
+	return self
+```
+
+**Step 3: Update `build()` — apply deck before bag fallback**
+
+In `build()`, replace the existing bag-config block:
+
+```gdscript
+# OLD (lines ~65-72):
+if _bag_config:
+    run.bag_config = _bag_config
+else:
+    var default_bag := load("res://Data/BagDistribution/bag_default.tres") as BagDistribution
+    if default_bag == null:
+        push_error("[RunBuilder] Failed to load default bag distribution")
+    run.bag_config = default_bag
+```
+
+Replace with:
+
+```gdscript
+if _deck:
+    run.bag_config = _deck.create_distribution()
+    var bundled := _deck.create_bundled_quality()
+    if bundled != null:
+        add_quality(bundled)
+elif _bag_config:
+    run.bag_config = _bag_config
+else:
+    var default_bag := load("res://Data/BagDistribution/bag_default.tres") as BagDistribution
+    if default_bag == null:
+        push_error("[RunBuilder] Failed to load default bag distribution")
+    run.bag_config = default_bag
+```
+
+**Step 4: Verify**
+
+Launch game (`F5`) and start a new game using the existing flow (before UI rework). Game must reach gameplay without errors. Pass.
+
+**Step 5: Commit**
+
+```bash
+git add scripts/domain/run_builder.gd
+git commit -m "feat: add RunBuilder.set_deck() with auto-bundled quality support"
+```
+
+---
+
+## Task 8: Rework `RunSetupPopup` — add deck selector
+
+**Files:**
+- Modify: `scenes/title_screen/run_setup_popup.gd`
+
+**Step 1: Read the current file first**
+
+Open `scenes/title_screen/run_setup_popup.gd`. Key points:
+- `@onready var _quality_list: HBoxContainer = $Panel/MarginContainer/VBoxContainer/ScrollContainer/QualityList`
+- `_ready()` calls `_populate_quality_list()` which creates checkboxes dynamically
+- `_build_run()` hardcodes `builder.set_bag(load("res://Data/BagDistribution/bag_default.tres"))`
+
+**Step 2: Add new fields**
+
+Add after the existing `@onready` declarations:
+
+```gdscript
+@onready var _content_vbox: VBoxContainer = $Panel/MarginContainer/VBoxContainer
+
+var _deck_option: OptionButton = null
+var _deck_desc_label: Label = null
+var _deck_ids: Array[StringName] = []
+```
+
+**Step 3: Add `_populate_deck_selector()` private method**
+
+Add this new method (before `_populate_quality_list`):
+
+```gdscript
+func _populate_deck_selector() -> void:
+	# Deck label
+	var deck_label := Label.new()
+	deck_label.text = "Deck"
+	deck_label.add_theme_font_size_override("font_size", 14)
+
+	# OptionButton
+	_deck_option = OptionButton.new()
+	_deck_option.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	_deck_ids = DeckRegistry.get_all_deck_ids()
+	for id in _deck_ids:
+		var deck := DeckRegistry.create_default(id)
+		_deck_option.add_item(deck.get_display_name())
+	_deck_option.item_selected.connect(_on_deck_selected)
+
+	# Description label
+	_deck_desc_label = Label.new()
+	_deck_desc_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	_deck_desc_label.add_theme_font_size_override("font_size", 12)
+	_deck_desc_label.add_theme_color_override("font_color", Color(0.7, 0.7, 0.7))
+
+	# Section container
+	var section := VBoxContainer.new()
+	section.add_theme_constant_override("separation", 6)
+	section.add_child(deck_label)
+	section.add_child(_deck_option)
+	section.add_child(_deck_desc_label)
+
+	# Separator below deck section
+	var sep := HSeparator.new()
+
+	# Insert at top of content vbox (before ScrollContainer)
+	_content_vbox.add_child(section)
+	_content_vbox.add_child(sep)
+	_content_vbox.move_child(section, 0)
+	_content_vbox.move_child(sep, 1)
+
+	# Trigger initial description display
+	_on_deck_selected(0)
+```
+
+**Step 4: Add `_on_deck_selected()` callback and `_get_selected_deck()` helper**
+
+```gdscript
+func _on_deck_selected(index: int) -> void:
+	if _deck_desc_label == null or index >= _deck_ids.size():
+		return
+	var deck := DeckRegistry.create_default(_deck_ids[index])
+	if deck:
+		_deck_desc_label.text = deck.get_description()
+
+
+func _get_selected_deck() -> DeckDefinition:
+	var index := _deck_option.selected if _deck_option else 0
+	if index < 0 or index >= _deck_ids.size():
+		return StandardDeck.new()
+	return DeckRegistry.create_default(_deck_ids[index])
+```
+
+**Step 5: Update `_ready()` — call `_populate_deck_selector()`**
+
+In `_ready()`, add the call right before `_populate_quality_list()`:
+
+```gdscript
+func _ready() -> void:
+	_start_button.pressed.connect(_on_start_pressed)
+	_back_button.pressed.connect(_on_back_pressed)
+	set_process_input(true)
+	_populate_deck_selector()   # <- add this line
+	_populate_quality_list()
+```
+
+**Step 6: Update `_build_run()` — replace `set_bag` with `set_deck`**
+
+Find this line in `_build_run()`:
+
+```gdscript
+builder.set_bag(load("res://Data/BagDistribution/bag_default.tres"))
+```
+
+Replace with:
+
+```gdscript
+builder.set_deck(_get_selected_deck())
+```
+
+**Step 7: Verify in-game**
+
+1. Launch the game (`F5`).
+2. Click **New Game** on the title screen.
+3. The Run Setup popup must show a **Deck** dropdown at the top with three options: Standard, Equal, Cursed.
+4. Selecting each option must update the description label below the dropdown.
+5. Select **Standard** → click **Start** → gameplay loads with the normal tile bag (verify via Debug Console: press `D`, type `draw 10`, hand fills as expected).
+6. Select **Equal** → click **Start** → gameplay loads with 26-tile bag (bag runs out faster).
+7. Select **Cursed** → click **Start** → gameplay loads; all tiles in hand should show the RESET visual (inverted shader / no badges).
+
+**Step 8: Commit**
+
+```bash
+git add scenes/title_screen/run_setup_popup.gd
+git commit -m "feat: rework RunSetupPopup to add deck selector (Standard/Equal/Cursed)"
+```
+
+---
+
+## Final Verification Checklist
+
+Run through all three decks end-to-end:
+
+- [ ] Standard: familiar tile frequencies, no modifiers unless Random Modifiers quality selected
+- [ ] Equal: only 26 tiles total — bag empties quickly, hand draws show `[TileBag] Empty` sooner
+- [ ] Cursed: all drawn tiles show inverted shader (RESET visual); playing a tile shows the stomp animation (RESET denies spin); scoring shows base points only
+
+If any step fails, check the Output panel for errors — they will point to the exact line.
+
+---
+
+## Out of Scope (do not implement now)
+
+- Saving selected deck between sessions
+- Animated deck preview or card-flip UI
+- Deck unlocking / progression gates

--- a/docs/plans/CLAUDE.md
+++ b/docs/plans/CLAUDE.md
@@ -1,0 +1,48 @@
+# Documentation/Plans Directory
+
+## Purpose
+Contains feature design documents and implementation plans for Wordatro features. Each feature has paired design and plan documents.
+
+## Key Files
+- `2026-02-21-decks-design.md` - Design specification for deck selection feature
+- `2026-02-21-decks-plan.md` - Implementation plan for deck selection feature
+
+## Public Interfaces
+None (documentation only)
+
+## Dependencies
+None
+
+## Architecture / Patterns
+**Two-Document Pattern**:
+- **Design Document** (`*-design.md`): Defines the "what" and "why"
+  - Overview and goals
+  - Design principles (OOP, DDD, cyclomatic complexity)
+  - Domain model specifications
+  - API contracts and behavioral specifications
+  - Integration points
+  - Status tracking (Draft/Approved/Implemented)
+
+- **Implementation Plan** (`*-plan.md`): Defines the "how"
+  - Step-by-step task breakdown
+  - File-by-file changes with code snippets
+  - Reference to existing patterns to follow
+  - Verification steps for each task
+  - Required sub-skills and superpowers
+
+**Design Philosophy**:
+- Specification-driven: Behavioral contracts in doc comments
+- Domain-Driven Design: Model game concepts as value objects
+- Object-Oriented: Clear inheritance hierarchies and interfaces
+- Registry pattern for extensibility
+- Cyclomatic complexity ≤ 5
+
+## Conventions
+- File naming: `YYYY-MM-DD-feature-{design|plan}.md`
+- Design documents approved before implementation begins
+- Implementation plans reference existing code patterns to mirror
+- Tasks numbered sequentially with clear verification criteria
+- Code examples provided for new abstractions
+
+## Build / Test
+None (documentation only)

--- a/scenes/main.gd
+++ b/scenes/main.gd
@@ -77,8 +77,7 @@ func _start_run() -> void:
 	# If RunManager was not initialized (e.g., scene loaded directly for testing),
 	# initialize with defaults
 	if RunManager.run_state == null:
-		var default_bag: BagDistribution = load("res://Data/BagDistribution/bag_default.tres")
-		RunManager.initialize_run(default_bag)
+		RunManager.initialize_run_from_builder(RunBuilder.new().build())
 
 	# Populate tile bag once for the entire run
 	TileBag.populate_bag(RunManager.run_state.bag_config)

--- a/scenes/tile/tile.gd
+++ b/scenes/tile/tile.gd
@@ -33,9 +33,6 @@ var tile_data: LetterTileData = null
 var letter: String = ""
 var base_points: int = 0
 
-# === Legacy Point Modifier (see modifiers: Dictionary for composable modifiers) ===
-var point_modifier: int = 0        # Bonus/penalty to base points
-var is_wild: bool = false          # Wild card tile (unused)
 var is_locked: bool = false        # Cannot be moved once placed (synced from LOCKED modifier)
 
 # === Composable Modifiers ===
@@ -161,7 +158,7 @@ func _animate_selection_scale() -> void:
 
 ## Get the total point value including modifiers.
 func get_points() -> int:
-	return base_points + point_modifier
+	return base_points
 
 
 ## Check if this tile can be interacted with.
@@ -332,7 +329,6 @@ func reset() -> void:
 	detach_from_cell()
 	is_selected = false
 	is_locked = false
-	point_modifier = 0
 	modifiers.clear()
 	_remove_spark_effect()
 	location = TileLocation.IN_BAG

--- a/scenes/title_screen/run_setup_popup.gd
+++ b/scenes/title_screen/run_setup_popup.gd
@@ -18,12 +18,17 @@ signal cancelled()
 @onready var _quality_list: HBoxContainer = $Panel/MarginContainer/VBoxContainer/ScrollContainer/QualityList
 @onready var _start_button: Button = $Panel/MarginContainer/VBoxContainer/ButtonContainer/StartButton
 @onready var _back_button: Button = $Panel/MarginContainer/VBoxContainer/ButtonContainer/BackButton
+@onready var _content_vbox: VBoxContainer = $Panel/MarginContainer/VBoxContainer
 
 # =============================================================================
 # STATE
 # =============================================================================
 
 var _quality_checkboxes: Dictionary = {}  # StringName -> CheckBox
+
+var _deck_option: OptionButton = null
+var _deck_desc_label: Label = null
+var _deck_ids: Array[StringName] = []
 
 # =============================================================================
 # LIFECYCLE
@@ -33,6 +38,7 @@ func _ready() -> void:
 	_start_button.pressed.connect(_on_start_pressed)
 	_back_button.pressed.connect(_on_back_pressed)
 	set_process_input(true)
+	_populate_deck_selector()
 	_populate_quality_list()
 
 
@@ -59,6 +65,55 @@ func close_popup() -> void:
 # =============================================================================
 # PRIVATE
 # =============================================================================
+
+func _populate_deck_selector() -> void:
+	var deck_label := Label.new()
+	deck_label.text = "Deck"
+	deck_label.add_theme_font_size_override("font_size", 14)
+
+	_deck_option = OptionButton.new()
+	_deck_option.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	_deck_ids = DeckRegistry.get_all_deck_ids()
+	for id in _deck_ids:
+		var deck := DeckRegistry.create_default(id)
+		_deck_option.add_item(deck.get_display_name())
+	_deck_option.item_selected.connect(_on_deck_selected)
+
+	_deck_desc_label = Label.new()
+	_deck_desc_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	_deck_desc_label.add_theme_font_size_override("font_size", 12)
+	_deck_desc_label.add_theme_color_override("font_color", Color(0.7, 0.7, 0.7))
+
+	var section := VBoxContainer.new()
+	section.add_theme_constant_override("separation", 6)
+	section.add_child(deck_label)
+	section.add_child(_deck_option)
+	section.add_child(_deck_desc_label)
+
+	var sep := HSeparator.new()
+
+	_content_vbox.add_child(section)
+	_content_vbox.add_child(sep)
+	_content_vbox.move_child(section, 0)
+	_content_vbox.move_child(sep, 1)
+
+	_on_deck_selected(0)
+
+
+func _on_deck_selected(index: int) -> void:
+	if _deck_desc_label == null or index >= _deck_ids.size():
+		return
+	var deck := DeckRegistry.create_default(_deck_ids[index])
+	if deck:
+		_deck_desc_label.text = deck.get_description()
+
+
+func _get_selected_deck() -> DeckDefinition:
+	var index := _deck_option.selected if _deck_option else 0
+	if index < 0 or index >= _deck_ids.size():
+		return StandardDeck.new()
+	return DeckRegistry.create_default(_deck_ids[index])
+
 
 func _populate_quality_list() -> void:
 	# Clear existing children
@@ -105,7 +160,7 @@ func _populate_quality_list() -> void:
 
 func _build_run() -> Run:
 	var builder := RunBuilder.new()
-	builder.set_bag(load("res://Data/BagDistribution/bag_default.tres"))
+	builder.set_deck(_get_selected_deck())
 
 	for id in _quality_checkboxes:
 		var checkbox: CheckBox = _quality_checkboxes[id]

--- a/scenes/title_screen/run_setup_popup.gd
+++ b/scenes/title_screen/run_setup_popup.gd
@@ -101,7 +101,7 @@ func _populate_deck_selector() -> void:
 
 
 func _on_deck_selected(index: int) -> void:
-	if _deck_desc_label == null or index >= _deck_ids.size():
+	if _deck_desc_label == null or index < 0 or index >= _deck_ids.size():
 		return
 	var deck := DeckRegistry.create_default(_deck_ids[index])
 	if deck:

--- a/scenes/title_screen/run_setup_popup.gd
+++ b/scenes/title_screen/run_setup_popup.gd
@@ -97,7 +97,8 @@ func _populate_deck_selector() -> void:
 	_content_vbox.move_child(section, 0)
 	_content_vbox.move_child(sep, 1)
 
-	_on_deck_selected(0)
+	var default_index := _deck_ids.find(&"standard")
+	_on_deck_selected(maxi(default_index, 0))
 
 
 func _on_deck_selected(index: int) -> void:
@@ -111,7 +112,7 @@ func _on_deck_selected(index: int) -> void:
 func _get_selected_deck() -> DeckDefinition:
 	var index := _deck_option.selected if _deck_option else 0
 	if index < 0 or index >= _deck_ids.size():
-		return StandardDeck.new()
+		return DeckRegistry.create_default(&"standard")
 	return DeckRegistry.create_default(_deck_ids[index])
 
 

--- a/scenes/ui/main_hud/main_hud.gd
+++ b/scenes/ui/main_hud/main_hud.gd
@@ -153,16 +153,27 @@ func _connect_timer_qualities() -> void:
 		if quality.has_timer():
 			has_timer = true
 
+	print("[MainHUD] Connected timer signals for %d qualities (has_timer=%s)" % [run.qualities.size(), has_timer])
 	timer_label.visible = has_timer
 	timer_increment_label.visible = false
 
 
 func _disconnect_timer_qualities() -> void:
+	if _timer_connections.is_empty():
+		return
+	var disconnected := 0
+	var skipped_freed := 0
 	for conn in _timer_connections:
 		var sig: Signal = conn["signal"]
 		var cb: Callable = conn["callable"]
+		# Guard: source object may have been freed (e.g. RunManager.reset() called first)
+		if not is_instance_valid(sig.get_object()):
+			skipped_freed += 1
+			continue
 		if sig.is_connected(cb):
 			sig.disconnect(cb)
+			disconnected += 1
+	print("[MainHUD] Disconnected timer signals: %d disconnected, %d skipped (source freed)" % [disconnected, skipped_freed])
 	_timer_connections.clear()
 
 

--- a/scripts/animation/draw/draw_tile_animation.gd
+++ b/scripts/animation/draw/draw_tile_animation.gd
@@ -10,7 +10,6 @@ class_name DrawTileAnimation
 
 @export var vertical_offset: float = 200.0
 @export var start_scale: Vector2 = Vector2(0.8, 0.8)
-@export var start_alpha: float = 0.0  # Currently unused; alpha set directly in on_animation_start
 
 
 func _init() -> void:
@@ -41,9 +40,7 @@ func get_end_properties() -> Dictionary:
 
 
 func on_animation_start(tile: Tile) -> void:
-	# Disable interaction during animation
 	tile.mouse_filter = Control.MOUSE_FILTER_IGNORE
-	# Apply modifier visual first (tint + invert), then set alpha to 0
 	tile._apply_modifier_visual()
 	tile.modulate.a = 0.0
 

--- a/scripts/animation/spin/CLAUDE.md
+++ b/scripts/animation/spin/CLAUDE.md
@@ -1,0 +1,82 @@
+# Spin Animation
+
+## Purpose
+Provides rotation and scale animation for tiles with special modifiers (EXTRA, MULTI, EXPO). Tiles spin 360 degrees while scaling up and back down.
+
+## Key Files
+- `spin_tile_animation.gd` - SpinTileAnimation strategy (defines WHAT happens)
+- `spin_animation_executor.gd` - SpinAnimationExecutor (defines HOW it executes)
+
+## Public Interfaces
+
+### SpinTileAnimation (Strategy)
+```gdscript
+class_name SpinTileAnimation extends TileAnimationStrategy
+
+# Configuration
+@export var peak_scale: Vector2 = Vector2(1.25, 1.25)
+@export var spin_up_duration: float = 0.15
+@export var spin_down_duration: float = 0.20
+
+# Overrides
+func get_start_position_offset() -> Vector2
+func get_start_properties() -> Dictionary
+func get_end_properties() -> Dictionary
+func on_animation_start(tile: Tile) -> void
+func on_animation_complete(tile: Tile) -> void
+```
+
+### SpinAnimationExecutor (Executor)
+```gdscript
+class_name SpinAnimationExecutor extends AnimationExecutor
+
+func execute(tiles: Array[Tile], strategy: SpinTileAnimation) -> void
+```
+
+## Dependencies
+
+### Internal
+- `TileAnimationStrategy` - Base strategy class
+- `AnimationExecutor` - Base executor class
+- `Tile` - Tile node being animated
+- `AnimationContext` - Shared animation state
+
+### External (Godot)
+- `Tween` - Animation interpolation
+- `Control` - Mouse filtering during animation
+
+## Architecture / Patterns
+
+**Strategy Pattern**: SpinTileAnimation defines animation parameters and lifecycle hooks; SpinAnimationExecutor implements the execution logic.
+
+**Two-Phase Animation**:
+1. **Spin Up (0.15s)**: Scale increases to 1.25x, rotation begins
+2. **Spin Down (0.20s)**: Scale returns to 1.0x, rotation completes 360°
+
+**Parallel Tweening**: Scale and rotation animate simultaneously during spin-up phase.
+
+**Batch Support**: Executor supports staggered animation of multiple tiles with configurable delay.
+
+## Conventions
+
+### Animation Lifecycle
+1. Disable mouse interaction (`MOUSE_FILTER_IGNORE`)
+2. Elevate z-index to 50 (above other tiles)
+3. Set pivot offset to tile center for rotation
+4. Execute two-phase tween animation
+5. Restore visual state (locked tint, modifier tint)
+6. Reset z-index, pivot, rotation, mouse filter
+
+### Tween Configuration
+- **Ease Type**: `EASE_OUT`, `EASE_IN_OUT` (phase-dependent)
+- **Trans Type**: `TRANS_BACK` (spin-up), `TRANS_CUBIC` (spin-down)
+- **Stagger Delay**: 0.06s between tiles in batch
+
+### Visual Restoration
+After animation completes, calls `tile._update_visual()` to restore:
+- Locked overlay (if tile is locked)
+- Modifier tint (EXTRA=purple, MULTI=orange, EXPO=red)
+- Selection state
+
+## Build / Test
+Run game (`F5`) and observe tiles with EXTRA/MULTI/EXPO modifiers spinning after placement or round start. Verify smooth rotation, scale pulse, and proper visual state restoration.

--- a/scripts/controllers/drop_handler.gd
+++ b/scripts/controllers/drop_handler.gd
@@ -14,10 +14,6 @@ var hand: Hand = null
 var _selection: SelectionManager = null
 var _drag_mgr: DragManager = null
 
-## Tracks whether the last drop was successful (read by coordinator).
-var last_placement_success: bool = false
-
-
 func setup(placement: TilePlacementHandler, p_hand: Hand, p_selection: SelectionManager, p_drag_mgr: DragManager) -> void:
 	_placement = placement
 	hand = p_hand
@@ -33,7 +29,6 @@ func setup(placement: TilePlacementHandler, p_hand: Hand, p_selection: Selection
 ## Validates placement, handles cancellation with animation, or places tiles.
 func handle_tile_drop(drop_cell: BoardCell, tiles: Array[Tile]) -> bool:
 	if tiles.is_empty():
-		last_placement_success = false
 		return false
 
 	var has_board_tiles: bool = _any_tiles_on_board(tiles)
@@ -41,11 +36,9 @@ func handle_tile_drop(drop_cell: BoardCell, tiles: Array[Tile]) -> bool:
 
 	if target_cells.is_empty():
 		_handle_invalid_drop(tiles, has_board_tiles, drop_cell)
-		last_placement_success = false
 		return false
 
 	_execute_valid_drop(tiles, target_cells)
-	last_placement_success = true
 	return true
 
 

--- a/scripts/controllers/gameplay_controller.gd
+++ b/scripts/controllers/gameplay_controller.gd
@@ -27,8 +27,8 @@ enum InteractionMode {
 	DRAGGING        # Tile being dragged
 }
 
-var interaction_mode: InteractionMode = InteractionMode.IDLE
-var selected_tile: Tile = null
+var _interaction_mode: InteractionMode = InteractionMode.IDLE
+var _selected_tile: Tile = null
 var _is_active: bool = false
 
 # =============================================================================
@@ -60,7 +60,7 @@ var _play: PlayHandler = null
 # SIGNAL CONNECTION TRACKING
 # =============================================================================
 
-var _connections: Array[Dictionary] = []
+var _tracker: SignalTracker = SignalTracker.new()
 
 
 # =============================================================================
@@ -109,8 +109,16 @@ func setup(p_board: Board, p_hand: Hand, p_discard_pile: Control, p_discard_dial
 	_drop.setup(_placement, hand, _selection, _drag_mgr)
 
 	_play = PlayHandler.new()
-	_play.setup(board, main_hud, _selection)
+	_play.setup(board, _selection)
 	_play.play_completed.connect(func(tiles, words): play_completed.emit(tiles, words))
+	_play.draw_blocked_changed.connect(
+		func(blocked): main_hud.set_draw_button_blocked(blocked)
+	)
+	_play.play_button_changed.connect(
+		func(enabled, mode):
+			main_hud.set_play_button_enabled(enabled)
+			main_hud.set_play_button_mode(mode)
+	)
 
 
 ## Activates the controller and connects all signals.
@@ -128,7 +136,7 @@ func deactivate() -> void:
 	if not _is_active:
 		return
 	_is_active = false
-	_disconnect_all()
+	_tracker.disconnect_all()
 	_selection.deselect_all()
 	print("[GameplayController] Deactivated")
 
@@ -137,42 +145,24 @@ func deactivate() -> void:
 # SIGNAL CONNECTION MANAGEMENT
 # =============================================================================
 
-func _safe_connect(sig: Signal, handler: Callable) -> void:
-	sig.connect(handler)
-	_connections.append({"signal": sig, "handler": handler})
-
-
-func _disconnect_all() -> void:
-	for conn in _connections:
-		if conn.signal.is_connected(conn.handler):
-			conn.signal.disconnect(conn.handler)
-	_connections.clear()
-
-
 func _connect_signals() -> void:
-	# Board signals
 	if board:
-		_safe_connect(board.cell_clicked, _on_cell_clicked)
-		_safe_connect(board.cell_hovered, _on_cell_hovered)
-		_safe_connect(board.cell_unhovered, _on_cell_unhovered)
+		_tracker.track(board.cell_clicked, _on_cell_clicked)
+		_tracker.track(board.cell_hovered, _on_cell_hovered)
+		_tracker.track(board.cell_unhovered, _on_cell_unhovered)
 
-	# Discard signals
 	if discard_pile:
-		_safe_connect(discard_pile.tiles_dropped, _on_discard_pile_tiles_dropped)
-		_safe_connect(discard_pile.discard_clicked, _on_discard_pile_clicked)
-		_safe_connect(discard_pile.peek_requested, _on_discard_pile_peek_requested)
+		_tracker.track(discard_pile.tiles_dropped, _on_discard_pile_tiles_dropped)
+		_tracker.track(discard_pile.discard_clicked, _on_discard_pile_clicked)
+		_tracker.track(discard_pile.peek_requested, _on_discard_pile_peek_requested)
 
-	# HUD signals
 	if main_hud:
-		_safe_connect(main_hud.draw_requested, _on_draw_requested)
-		_safe_connect(main_hud.play_requested, _on_play_requested)
+		_tracker.track(main_hud.draw_requested, _on_draw_requested)
+		_tracker.track(main_hud.play_requested, _on_play_requested)
 
-	# Drag signals
-	_safe_connect(_drag_mgr.drag_release_requested, _handle_drag_release)
-
-	# Tile supply signals (for Play/End Round button state)
-	_safe_connect(EventBus.hand_count_changed, _on_tile_supply_changed)
-	_safe_connect(EventBus.bag_count_changed, _on_tile_supply_changed)
+	_tracker.track(_drag_mgr.drag_release_requested, _handle_drag_release)
+	_tracker.track(EventBus.hand_count_changed, _on_tile_supply_changed)
+	_tracker.track(EventBus.bag_count_changed, _on_tile_supply_changed)
 
 
 # =============================================================================
@@ -201,20 +191,15 @@ func _on_tile_selected(tile: Tile) -> void:
 
 	print("[Gameplay] Tile selected: %s" % tile.name)
 
-	# Clicking a board tile while we have selection
-	if _selection.has_selection() and tile.location == Tile.TileLocation.ON_BOARD:
-		print("[Gameplay] Cannot stack tiles")
-		return
-
-	# Clicking a tile that's already on the board (info only)
-	if not _selection.has_selection() and tile.location == Tile.TileLocation.ON_BOARD:
-		print("[Gameplay] Board tile at cell: %s" % tile.current_cell.name)
-		return
-
-	# Hand tile - use SelectionManager
-	if tile.location == Tile.TileLocation.IN_HAND:
-		_selection.select_tile(tile)
-		_update_interaction_state()
+	match tile.location:
+		Tile.TileLocation.ON_BOARD:
+			if _selection.has_selection():
+				print("[Gameplay] Cannot stack tiles")
+			else:
+				print("[Gameplay] Board tile at cell: %s" % tile.current_cell.name)
+		Tile.TileLocation.IN_HAND:
+			_selection.select_tile(tile)
+			_update_interaction_state()
 
 
 func _on_tile_right_clicked(tile: Tile) -> void:
@@ -245,41 +230,36 @@ func _on_tile_right_clicked(tile: Tile) -> void:
 	_play.update_play_button_state()
 
 
-func _on_tile_drag_started(tile: Tile) -> void:
-	if not _is_active:
-		return
-
-	# Safety check - tile should have prevented this, but double-check
-	if not tile.can_interact():
-		print("[Gameplay] Cannot drag non-interactable tile: %s" % tile.name)
-		return
-
-	var tiles_to_drag: Array[Tile] = _selection.get_selected_tiles()
-
-	# Filter out any locked/non-interactable tiles from multi-drag
-	var valid_tiles: Array[Tile] = []
-	for t in tiles_to_drag:
+## Builds the list of tiles to drag. Ensures lead tile is always included.
+## Removes followers that refuse drag. Resets selection if lead was not selected.
+func _collect_drag_candidates(tile: Tile) -> Array[Tile]:
+	var candidates: Array[Tile] = []
+	for t in _selection.get_selected_tiles():
 		if t.can_interact():
-			valid_tiles.append(t)
+			candidates.append(t)
 
-	if tile not in valid_tiles:
+	if tile not in candidates:
 		_selection.deselect_all()
 		_selection.select_tile(tile)
-		valid_tiles = [tile]
+		return [tile]
 
-	# Set follower tiles (skip lead tile)
-	for t in valid_tiles:
-		if t != tile:
-			if not t.set_as_drag_follower():
-				# Tile refused to be a follower (locked), remove from drag
-				valid_tiles.erase(t)
+	for t in candidates.duplicate():
+		if t != tile and not t.set_as_drag_follower():
+			candidates.erase(t)
 
+	return candidates
+
+
+func _on_tile_drag_started(tile: Tile) -> void:
+	if not _is_active or not tile.can_interact():
+		return
+
+	var valid_tiles := _collect_drag_candidates(tile)
 	if valid_tiles.is_empty():
 		print("[Gameplay] No valid tiles to drag")
 		return
 
 	_drag_mgr.start_drag(tile, valid_tiles)
-
 	if valid_tiles.size() > 1:
 		print("[Gameplay] Multi-drag started with %d tiles" % valid_tiles.size())
 
@@ -319,63 +299,55 @@ func _handle_drag_release(tile: Tile) -> void:
 	])
 
 	# Unified drop handling for single and multi-tile
-	_drop.handle_tile_drop(cell, dragged_tiles)
+	var success := _drop.handle_tile_drop(cell, dragged_tiles)
 	_update_interaction_state()
 	_play.update_play_button_state()
-	_drag_mgr.end_drag(_drop.last_placement_success)
+	_drag_mgr.end_drag(success)
 
 
 # =============================================================================
 # CELL HANDLERS
 # =============================================================================
 
+## Places one or more movable tiles starting at the target cell.
+func _place_tiles_on_cell(movable: Array[Tile], cell: BoardCell) -> void:
+	if movable.size() > 1:
+		var cells: Array[BoardCell] = _placement.get_sequential_cells(cell, movable.size())
+		if cells.is_empty():
+			print("[Gameplay] Cannot place %d tiles starting at %s" % [movable.size(), cell.name])
+			return
+		for i in movable.size():
+			_placement.place_tile_on_cell_silent(movable[i], cells[i])
+		print("[Gameplay] Placed %d tiles starting at %s" % [movable.size(), cell.name])
+	else:
+		_placement.place_tile_on_cell(movable[0], cell)
+	_selection.deselect_all()
+	_update_interaction_state()
+	_play.update_play_button_state()
+	tile_placement_completed.emit(movable[0], cell)
+
+
 func _on_cell_clicked(cell: BoardCell) -> void:
 	if not _is_active:
 		return
 
-	var selected_tiles: Array[Tile] = _selection.get_selected_tiles()
-
-	if selected_tiles.is_empty():
+	var selected: Array[Tile] = _selection.get_selected_tiles()
+	if selected.is_empty():
 		print("[Gameplay] No tile selected")
 		return
 
-	# Filter out locked tiles - they cannot be moved
-	var movable_tiles: Array[Tile] = []
-	for tile in selected_tiles:
-		if not tile.is_locked:
-			movable_tiles.append(tile)
-
-	if movable_tiles.is_empty():
+	var movable: Array[Tile] = selected.filter(func(t): return not t.is_locked)
+	if movable.is_empty():
 		print("[Gameplay] All selected tiles are locked")
 		_selection.deselect_all()
 		_update_interaction_state()
 		return
 
-	selected_tiles = movable_tiles
-
 	if cell.is_occupied():
 		print("[Gameplay] Cell occupied: %s" % cell.name)
 		return
 
-	if selected_tiles.size() > 1:
-		var cells: Array[BoardCell] = _placement.get_sequential_cells(cell, selected_tiles.size())
-		if cells.is_empty():
-			print("[Gameplay] Cannot place %d tiles starting at %s" % [selected_tiles.size(), cell.name])
-			return
-
-		for i in selected_tiles.size():
-			_placement.place_tile_on_cell_silent(selected_tiles[i], cells[i])
-
-		_selection.deselect_all()
-		_update_interaction_state()
-		_play.update_play_button_state()
-		tile_placement_completed.emit(selected_tiles[0], cell)
-		print("[Gameplay] Placed %d tiles starting at %s" % [selected_tiles.size(), cell.name])
-	else:
-		_placement.place_tile_on_cell(selected_tiles[0], cell)
-		_update_interaction_state()
-		_play.update_play_button_state()
-		tile_placement_completed.emit(selected_tiles[0], cell)
+	_place_tiles_on_cell(movable, cell)
 
 
 func _on_cell_hovered(cell: BoardCell) -> void:
@@ -412,10 +384,10 @@ func _on_cell_unhovered(cell: BoardCell) -> void:
 
 ## Discards selected hand tiles directly (no confirmation).
 func _request_discard() -> void:
-	var selected_tiles: Array[Tile] = _selection.get_selected_tiles()
+	var _selected_tiles: Array[Tile] = _selection.get_selected_tiles()
 
 	var hand_tiles: Array[Tile] = []
-	for tile in selected_tiles:
+	for tile in _selected_tiles:
 		if tile.location == Tile.TileLocation.IN_HAND:
 			hand_tiles.append(tile)
 
@@ -538,12 +510,12 @@ func _update_interaction_state() -> void:
 	var has_selection: bool = _selection.has_selection()
 
 	if has_selection:
-		interaction_mode = InteractionMode.TILE_SELECTED
-		selected_tile = _selection.get_selected_tiles()[0] if _selection.get_selection_count() == 1 else null
+		_interaction_mode = InteractionMode.TILE_SELECTED
+		_selected_tile = _selection.get_selected_tiles()[0] if _selection.get_selection_count() == 1 else null
 		_set_hand_tiles_hover_enabled(false)
 	else:
-		interaction_mode = InteractionMode.IDLE
-		selected_tile = null
+		_interaction_mode = InteractionMode.IDLE
+		_selected_tile = null
 		_set_hand_tiles_hover_enabled(true)
 		_placement.clear_all_cell_hovers()
 

--- a/scripts/controllers/play_handler.gd
+++ b/scripts/controllers/play_handler.gd
@@ -10,20 +10,20 @@ extends RefCounted
 # =============================================================================
 
 signal play_completed(tiles: Array[Tile], words: Array)
+signal draw_blocked_changed(blocked: bool)
+signal play_button_changed(enabled: bool, end_round_mode: bool)
 
 # =============================================================================
 # DEPENDENCIES (injected via setup)
 # =============================================================================
 
 var board: Board = null
-var main_hud: CanvasLayer = null
 var _word_validator: WordValidator = null
 var _selection: SelectionManager = null
 
 
-func setup(p_board: Board, p_hud: CanvasLayer, p_selection: SelectionManager) -> void:
+func setup(p_board: Board, p_selection: SelectionManager) -> void:
 	board = p_board
-	main_hud = p_hud
 	_selection = p_selection
 	_word_validator = WordValidator.new()
 
@@ -70,21 +70,10 @@ func on_play_requested() -> void:
 	# Animate ALL board tiles (locked and newly locked)
 	var all_tiles: Array[Tile] = _get_all_board_tiles()
 
-	# Split by animation type BEFORE consuming (modifiers still present):
-	# RESET dominates → stomp (denies special animations)
-	# EXTRA / MULTI / EXPO (no RESET) → spin
-	# Everything else → stomp
-	var spin_tiles: Array[Tile] = []
-	var stomp_tiles: Array[Tile] = []
-	for tile in all_tiles:
-		if tile.has_modifier(ModifierTypes.Type.RESET):
-			stomp_tiles.append(tile)
-		elif tile.has_modifier(ModifierTypes.Type.EXTRA) \
-			or tile.has_modifier(ModifierTypes.Type.MULTI) \
-			or tile.has_modifier(ModifierTypes.Type.EXPO):
-			spin_tiles.append(tile)
-		else:
-			stomp_tiles.append(tile)
+	# Split by animation type BEFORE consuming (modifiers still present)
+	var cats := _categorize_tiles_by_animation(all_tiles)
+	var spin_tiles: Array[Tile] = cats.spin
+	var stomp_tiles: Array[Tile] = cats.stomp
 
 	# Hide locked border during animations (on_animation_complete restores it)
 	for tile in all_tiles:
@@ -92,7 +81,7 @@ func on_play_requested() -> void:
 			tile.locked_border.visible = false
 
 	# Block draw button during play animations
-	main_hud.set_draw_button_blocked(true)
+	draw_blocked_changed.emit(true)
 
 	var animation_count: int = 0
 	if not stomp_tiles.is_empty():
@@ -106,7 +95,7 @@ func on_play_requested() -> void:
 	for i in animation_count:
 		await TileAnimator.animation_completed
 
-	main_hud.set_draw_button_blocked(false)
+	draw_blocked_changed.emit(false)
 
 	# Consume CONSUMABLE modifiers on newly played tiles after animation
 	for tile in unplayed_tiles:
@@ -129,7 +118,7 @@ func _auto_end_round() -> void:
 	print("[Gameplay] Auto end round: consuming %d remaining plays" % GameManager.get_plays_remaining())
 
 	# Disable button during auto-play sequence
-	main_hud.set_play_button_enabled(false)
+	play_button_changed.emit(false, false)
 
 	# Get all board tiles and their positions
 	var all_tiles: Array[Tile] = _get_all_board_tiles()
@@ -160,17 +149,9 @@ func _auto_end_round() -> void:
 	print("[Gameplay] Auto end round: scoring %d pts per play from %d words" % [total_score, words.size()])
 
 	# Split ALL tiles by animation type (once, modifiers don't change between loops)
-	var spin_tiles: Array[Tile] = []
-	var stomp_tiles: Array[Tile] = []
-	for tile in all_tiles:
-		if tile.has_modifier(ModifierTypes.Type.RESET):
-			stomp_tiles.append(tile)
-		elif tile.has_modifier(ModifierTypes.Type.EXTRA) \
-			or tile.has_modifier(ModifierTypes.Type.MULTI) \
-			or tile.has_modifier(ModifierTypes.Type.EXPO):
-			spin_tiles.append(tile)
-		else:
-			stomp_tiles.append(tile)
+	var cats := _categorize_tiles_by_animation(all_tiles)
+	var spin_tiles: Array[Tile] = cats.spin
+	var stomp_tiles: Array[Tile] = cats.stomp
 
 	# Loop: hide borders -> animate -> await -> commit for each remaining play
 	while GameManager.get_current_phase() == GameManager.GamePhase.PLAYING and GameManager.get_plays_remaining() > 0:
@@ -215,6 +196,22 @@ func _get_all_board_tiles() -> Array[Tile]:
 	return tiles
 
 
+## Splits tiles into spin (EXTRA/MULTI/EXPO) and stomp (RESET/plain) groups.
+func _categorize_tiles_by_animation(tiles: Array[Tile]) -> Dictionary:
+	var spin: Array[Tile] = []
+	var stomp: Array[Tile] = []
+	for tile in tiles:
+		if tile.has_modifier(ModifierTypes.Type.RESET):
+			stomp.append(tile)
+		elif tile.has_modifier(ModifierTypes.Type.EXTRA) \
+			or tile.has_modifier(ModifierTypes.Type.MULTI) \
+			or tile.has_modifier(ModifierTypes.Type.EXPO):
+			spin.append(tile)
+		else:
+			stomp.append(tile)
+	return {spin = spin, stomp = stomp}
+
+
 ## Checks if the player has any valid moves remaining.
 func has_valid_moves() -> bool:
 	# Valid moves exist if there are unplayed tiles on the board
@@ -239,17 +236,10 @@ func has_valid_moves() -> bool:
 
 ## Updates the Play/End Round button state based on current board state.
 func update_play_button_state() -> void:
-	if not main_hud:
-		return
-
-	var has_unplayed_tiles: bool = not _get_unplayed_board_tiles().is_empty()
-
-	if has_unplayed_tiles:
-		main_hud.set_play_button_enabled(true)
-		main_hud.set_play_button_mode(false)
+	var has_unplayed: bool = not _get_unplayed_board_tiles().is_empty()
+	if has_unplayed:
+		play_button_changed.emit(true, false)
 	elif not has_valid_moves() and GameManager.get_plays_remaining() > 0:
-		main_hud.set_play_button_enabled(true)
-		main_hud.set_play_button_mode(true)
+		play_button_changed.emit(true, true)
 	else:
-		main_hud.set_play_button_enabled(false)
-		main_hud.set_play_button_mode(false)
+		play_button_changed.emit(false, false)

--- a/scripts/domain/decks/CLAUDE.md
+++ b/scripts/domain/decks/CLAUDE.md
@@ -1,0 +1,133 @@
+# Domain/Decks Directory
+
+## Purpose
+Contains deck definitions and DeckRegistry. Decks define tile pool distributions and optional bundled RunQuality modifiers. Players select a deck in the Run Setup popup before starting a run.
+
+## Key Files
+- `deck_definition.gd` - Abstract base class for deck definitions
+- `deck_registry.gd` - Static factory registry for deck instantiation
+- `standard_deck.gd` - Standard Scrabble-style distribution (98 tiles, frequency-weighted)
+- `equal_deck.gd` - Equal distribution (26 tiles, 1 of each letter)
+- `cursed_deck.gd` - Standard distribution with bundled AllResetQuality (all tiles carry RESET)
+
+## Public Interfaces
+
+### DeckRegistry (Static Factory)
+```gdscript
+class_name DeckRegistry extends RefCounted
+
+static func register(id: StringName, factory: Callable) -> void
+static func create_default(id: StringName) -> DeckDefinition
+static func get_all_deck_ids() -> Array[StringName]
+```
+
+### DeckDefinition (Abstract Base Class)
+```gdscript
+class_name DeckDefinition extends RefCounted
+
+# Identity
+func get_id() -> StringName
+func get_display_name() -> String
+func get_description() -> String
+
+# Factory methods
+func create_distribution() -> BagDistribution
+func create_bundled_quality() -> RunQuality  # default: return null
+```
+
+**Preconditions**:
+- `get_id()` returns a non-empty, unique StringName
+- `create_distribution()` returns a non-null BagDistribution where `is_valid() == true`
+
+**Invariants**:
+- `create_bundled_quality()` returns `null` or a valid RunQuality instance
+- All methods are pure (no side-effects, no global state)
+
+## Dependencies
+
+### Internal
+- `Data/BagDistribution/bag_distribution.gd` - BagDistribution resource class
+- `Data/BagDistribution/bag_default.tres` - Standard distribution resource
+- `Data/BagDistribution/bag_equal.tres` - Equal distribution resource
+- `scripts/domain/run_quality.gd` - Abstract quality base class
+- `scripts/domain/qualities/all_reset_quality.gd` - RESET modifier quality (Cursed deck)
+
+### External (Godot)
+- `RefCounted` - Base class for deck objects
+- `StringName` - For deck IDs
+- `load()` - Resource loading
+
+## Architecture / Patterns
+
+**Domain-Driven Design**: DeckDefinition is a value object representing a deck configuration, not a scene node.
+
+**Registry Pattern**: Static factory with lazy initialization. Three built-in decks registered in `_ensure_initialized()`.
+
+**Factory Method Pattern**: 
+- DeckRegistry creates DeckDefinition instances
+- DeckDefinition creates BagDistribution resources
+- DeckDefinition creates optional RunQuality instances
+
+**Strategy Pattern**: Deck selection determines tile distribution and bundled quality behavior.
+
+**Composition**: Decks compose:
+1. **BagDistribution** (required) - Defines tile pool composition
+2. **RunQuality** (optional) - Defines gameplay modifiers
+
+**Built-in Decks**:
+
+| Deck ID | Display Name | Distribution | Bundled Quality | Description |
+|---------|-------------|--------------|-----------------|-------------|
+| `standard` | Standard | `bag_default.tres` (98 tiles) | None | Classic Scrabble-style frequency-weighted letters |
+| `equal` | Equal | `bag_equal.tres` (26 tiles) | None | One of each letter (A-Z) |
+| `cursed` | Cursed | `bag_default.tres` (98 tiles) | AllResetQuality | All tiles carry RESET modifier each round |
+
+## Conventions
+
+### Deck ID Naming
+- Snake case StringNames: `&"standard"`, `&"equal"`, `&"cursed"`
+- IDs must be unique across all decks
+- Registry lookup returns `null` and logs warning for unknown IDs
+
+### Distribution Loading
+```gdscript
+func create_distribution() -> BagDistribution:
+    return load("res://Data/BagDistribution/bag_name.tres") as BagDistribution
+```
+
+### Bundled Quality Pattern
+```gdscript
+func create_bundled_quality() -> RunQuality:
+    return ConcreteQuality.new()  # or return null for no quality
+```
+
+### Registration Pattern
+```gdscript
+_factories[&"deck_id"] = func() -> DeckDefinition: return ConcreteDeck.new()
+```
+
+### Behavioral Contracts
+All deck methods carry specification contracts in doc comments:
+- **Preconditions**: Requirements before method execution
+- **Postconditions**: Guarantees after method execution
+- **Invariants**: Properties that always hold
+
+### Cyclomatic Complexity
+All methods maintain cyclomatic complexity ≤ 5. Complex logic decomposed into helper methods.
+
+## Build / Test
+Test deck selection and behavior:
+1. Launch game (`F5`)
+2. Open Run Setup popup
+3. Select different decks from dropdown
+4. Verify description updates correctly
+5. Start run and verify:
+   - Tile pool matches expected distribution
+   - Bundled quality activates (for Cursed deck: all tiles show RESET)
+   - Hand refills correctly from deck
+6. Complete round and verify tile bag empties as expected
+
+**Verification Points**:
+- Standard: Common letters (E, A, T) appear frequently
+- Equal: Only 26 tiles total, one of each letter
+- Cursed: All drawn tiles display RESET modifier indicator

--- a/scripts/domain/decks/cursed_deck.gd
+++ b/scripts/domain/decks/cursed_deck.gd
@@ -1,0 +1,27 @@
+extends DeckDefinition
+class_name CursedDeck
+
+## CursedDeck: Standard distribution with AllResetQuality bundled.
+## Every tile drawn will carry the RESET modifier each round.
+##
+## Postcondition: create_distribution() returns bag_default.tres distribution.
+## Postcondition: create_bundled_quality() returns a valid AllResetQuality instance.
+
+func get_id() -> StringName:
+	return &"cursed"
+
+
+func get_display_name() -> String:
+	return "Cursed"
+
+
+func get_description() -> String:
+	return "Familiar letters, dark magic. All tiles carry the Reset modifier every round."
+
+
+func create_distribution() -> BagDistribution:
+	return load("res://Data/BagDistribution/bag_default.tres") as BagDistribution
+
+
+func create_bundled_quality() -> RunQuality:
+	return AllResetQuality.new()

--- a/scripts/domain/decks/cursed_deck.gd.uid
+++ b/scripts/domain/decks/cursed_deck.gd.uid
@@ -1,0 +1,1 @@
+uid://dlkcebq0h0wws

--- a/scripts/domain/decks/deck_definition.gd
+++ b/scripts/domain/decks/deck_definition.gd
@@ -1,0 +1,40 @@
+extends RefCounted
+class_name DeckDefinition
+
+## DeckDefinition: Abstract base for player-selectable tile decks.
+## A deck defines the tile pool (via create_distribution()) and may bundle
+## a RunQuality that modifies tile state each round (via create_bundled_quality()).
+##
+## Precondition : get_id() returns a non-empty, unique StringName.
+## Precondition : create_distribution() returns a non-null BagDistribution where is_valid() == true.
+## Invariant    : create_bundled_quality() returns null or a valid RunQuality instance.
+## Invariant    : all methods are pure (no side-effects, no global state).
+
+# =============================================================================
+# IDENTITY  (override in subclasses)
+# =============================================================================
+
+func get_id() -> StringName:
+	return &""
+
+
+func get_display_name() -> String:
+	return ""
+
+
+func get_description() -> String:
+	return ""
+
+# =============================================================================
+# FACTORY  (override in subclasses)
+# =============================================================================
+
+## Returns the tile distribution for this deck.
+## Postcondition: result != null and result.is_valid() == true.
+func create_distribution() -> BagDistribution:
+	return null
+
+
+## Returns a RunQuality to auto-bundle with the run, or null if none.
+func create_bundled_quality() -> RunQuality:
+	return null

--- a/scripts/domain/decks/deck_definition.gd.uid
+++ b/scripts/domain/decks/deck_definition.gd.uid
@@ -1,0 +1,1 @@
+uid://b8o4gicxyehmr

--- a/scripts/domain/decks/deck_registry.gd
+++ b/scripts/domain/decks/deck_registry.gd
@@ -1,0 +1,53 @@
+extends RefCounted
+class_name DeckRegistry
+
+## DeckRegistry: Static factory registry for DeckDefinition types.
+## Mirrors QualityRegistry. Maps deck IDs to factory callables.
+##
+## Precondition : _factories populated with standard, equal, cursed on first access.
+## Postcondition: create_default(unknown_id) returns null and logs a warning.
+## Invariant    : all registered IDs are unique StringNames.
+
+# =============================================================================
+# REGISTRY STATE
+# =============================================================================
+
+static var _factories: Dictionary = {}
+static var _initialized: bool = false
+
+# =============================================================================
+# PUBLIC API
+# =============================================================================
+
+static func register(id: StringName, factory: Callable) -> void:
+	_ensure_initialized()
+	_factories[id] = factory
+
+
+static func create_default(id: StringName) -> DeckDefinition:
+	_ensure_initialized()
+	if not _factories.has(id):
+		push_warning("[DeckRegistry] Unknown deck ID: %s" % id)
+		return null
+	return _factories[id].call()
+
+
+static func get_all_deck_ids() -> Array[StringName]:
+	_ensure_initialized()
+	var ids: Array[StringName] = []
+	for key in _factories.keys():
+		ids.append(key)
+	return ids
+
+# =============================================================================
+# INITIALIZATION
+# =============================================================================
+
+static func _ensure_initialized() -> void:
+	if _initialized:
+		return
+	_initialized = true
+
+	_factories[&"standard"] = func() -> DeckDefinition: return StandardDeck.new()
+	_factories[&"equal"]    = func() -> DeckDefinition: return EqualDeck.new()
+	_factories[&"cursed"]   = func() -> DeckDefinition: return CursedDeck.new()

--- a/scripts/domain/decks/deck_registry.gd.uid
+++ b/scripts/domain/decks/deck_registry.gd.uid
@@ -1,0 +1,1 @@
+uid://dmpx02l2p6xi6

--- a/scripts/domain/decks/equal_deck.gd
+++ b/scripts/domain/decks/equal_deck.gd
@@ -1,0 +1,22 @@
+extends DeckDefinition
+class_name EqualDeck
+
+## EqualDeck: One of each letter (26 tiles total).
+## No bundled quality.
+##
+## Postcondition: create_distribution() loads bag_equal.tres successfully.
+
+func get_id() -> StringName:
+	return &"equal"
+
+
+func get_display_name() -> String:
+	return "Equal"
+
+
+func get_description() -> String:
+	return "One of every letter. Each tile is equally likely — plan your words carefully."
+
+
+func create_distribution() -> BagDistribution:
+	return load("res://Data/BagDistribution/bag_equal.tres") as BagDistribution

--- a/scripts/domain/decks/equal_deck.gd.uid
+++ b/scripts/domain/decks/equal_deck.gd.uid
@@ -1,0 +1,1 @@
+uid://dt3j1t40bliyv

--- a/scripts/domain/decks/standard_deck.gd
+++ b/scripts/domain/decks/standard_deck.gd
@@ -1,0 +1,22 @@
+extends DeckDefinition
+class_name StandardDeck
+
+## StandardDeck: Scrabble-style distribution (frequency-weighted letters).
+## No bundled quality.
+##
+## Postcondition: create_distribution() loads bag_default.tres successfully.
+
+func get_id() -> StringName:
+	return &"standard"
+
+
+func get_display_name() -> String:
+	return "Standard"
+
+
+func get_description() -> String:
+	return "Classic Scrabble-style distribution. Common letters appear more often."
+
+
+func create_distribution() -> BagDistribution:
+	return load("res://Data/BagDistribution/bag_default.tres") as BagDistribution

--- a/scripts/domain/decks/standard_deck.gd.uid
+++ b/scripts/domain/decks/standard_deck.gd.uid
@@ -1,0 +1,1 @@
+uid://bxpssoky8m8le

--- a/scripts/domain/qualities/CLAUDE.md
+++ b/scripts/domain/qualities/CLAUDE.md
@@ -1,0 +1,119 @@
+# Domain/Qualities Directory
+
+## Purpose
+Contains all RunQuality implementations and the QualityRegistry. RunQualities are roguelike modifiers that alter gameplay rules (timers, hand size, round limits, random modifiers).
+
+## Key Files
+- `quality_registry.gd` - Static factory registry for RunQuality instantiation
+- `time_attack_quality.gd` - Countdown timer quality (120s per round)
+- `limited_time_with_increment_quality.gd` - Timer with per-play time bonus
+- `max_hand_size_quality.gd` - Increases hand size to 15 tiles
+- `max_score_in_n_rounds_quality.gd` - Must reach target score within N rounds
+- `random_modifiers_quality.gd` - Applies random modifiers to tiles each round
+- `all_reset_quality.gd` - All tiles carry RESET modifier
+- `auto_win_quality.gd` - Debug quality for instant victory
+
+## Public Interfaces
+
+### QualityRegistry (Static Factory)
+```gdscript
+class_name QualityRegistry extends RefCounted
+
+static func register(id: StringName, factory: Callable) -> void
+static func create_from_dict(data: Dictionary) -> RunQuality
+static func create_default(id: StringName) -> RunQuality
+static func get_all_quality_ids() -> Array[StringName]
+```
+
+### RunQuality (Abstract Base Class)
+Defined in parent directory (`scripts/domain/run_quality.gd`):
+```gdscript
+class_name RunQuality extends RefCounted
+
+# Identity
+func get_quality_id() -> StringName
+func get_quality_name() -> String
+func get_description() -> String
+
+# Lifecycle hooks
+func apply_to_run_state(run_state: RunState) -> void
+func on_round_started(round_number: int) -> void
+func on_round_ended(round_number: int, success: bool) -> void
+func on_process(delta: float) -> void
+
+# Serialization
+func to_dict() -> Dictionary
+func from_dict(data: Dictionary) -> void
+
+# Timer support
+func has_timer() -> bool
+
+# Signals
+signal time_updated(time_remaining: float)
+signal time_expired()
+```
+
+## Dependencies
+
+### Internal
+- `scripts/domain/run_quality.gd` - Abstract base class
+- `scripts/domain/run_state.gd` - Runtime state container
+- `scripts/domain/modifiers/modifier_registry.gd` - For random modifier creation
+- `autoload/tile_bag.gd` - Access to available tiles for modifier application
+
+### External (Godot)
+- `RefCounted` - Base class for quality objects
+- `StringName` - For quality IDs
+
+## Architecture / Patterns
+
+**Registry Pattern**: Static factory with lazy initialization. All built-in qualities registered in `_ensure_initialized()`.
+
+**Factory Method**: Each quality ID maps to a lambda that instantiates the concrete quality class.
+
+**Template Method**: RunQuality base class defines lifecycle hooks; subclasses override specific hooks.
+
+**Hook Architecture**:
+- `apply_to_run_state()` - Modify initial run configuration (hand size, plays)
+- `on_round_started()` - Initialize per-round state (timers, modifiers)
+- `on_round_ended()` - Cleanup, check win/loss conditions
+- `on_process()` - Per-frame updates (countdown timers)
+
+**Serialization Support**: Qualities can serialize/deserialize from Dictionary via `to_dict()` / `from_dict()`.
+
+## Conventions
+
+### Quality ID Naming
+- Snake case StringNames: `&"time_attack"`, `&"max_hand_size"`
+- IDs must be unique across all qualities
+- Registry lookup returns `null` and logs warning for unknown IDs
+
+### Timer Qualities
+- Override `has_timer() -> bool` to return `true`
+- Emit `time_updated(float)` signal during `on_process()`
+- Emit `time_expired()` when timer reaches zero
+- Store timer state in instance variables
+
+### State Modification Qualities
+- Override `apply_to_run_state()` to modify `RunState` before run begins
+- Examples: `max_hand_size`, `max_score_in_n_rounds`
+
+### Per-Round Modifier Qualities
+- Override `on_round_started()` to apply modifiers at round start
+- Use `TileBag.available_tiles` to access tiles
+- Use `ModifierRegistry.create_modifier()` to instantiate modifiers
+- Examples: `random_modifiers_quality`, `all_reset_quality`
+
+### Registration Pattern
+```gdscript
+_factories[&"quality_id"] = func() -> RunQuality: return ConcreteQuality.new()
+```
+
+## Build / Test
+Qualities are selected in RunSetupPopup before starting a run. Test by:
+1. Launch game (`F5`)
+2. Select quality in Run Setup dialog
+3. Start run and verify quality behavior
+4. Check timer HUD, hand size, or tile modifiers as appropriate
+
+**Debug Quality**: `auto_win` instantly completes rounds for testing.

--- a/scripts/domain/qualities/all_reset_quality.gd
+++ b/scripts/domain/qualities/all_reset_quality.gd
@@ -5,8 +5,8 @@ class_name AllResetQuality
 ## Bundled by CursedDeck; NOT registered in QualityRegistry (not shown in UI quality list).
 ##
 ## on_round_started:
-##   Precondition : TileBag.available_tiles is populated.
-##   Postcondition: every tile in TileBag.available_tiles carries a RESET/PER_ROUND modifier.
+##   Precondition : TileBag._available_tiles is populated.
+##   Postcondition: every tile in TileBag._available_tiles carries a RESET/PER_ROUND modifier.
 ##   Invariant    : tile.add_modifier() replaces by type — no duplicates possible.
 
 # =============================================================================
@@ -36,11 +36,11 @@ func on_round_started(_round_number: int) -> void:
 # =============================================================================
 
 func _apply_reset_to_all_bag_tiles() -> void:
-	for tile in TileBag.available_tiles:
+	for tile in TileBag.get_available_tiles():
 		var modifier: ModifierInstance = ModifierRegistry.create_modifier(
 			ModifierTypes.Type.RESET,
 			ModifierTypes.Tier.BRONZE,
 			ModifierTypes.Lifetime.PER_ROUND
 		)
 		tile.add_modifier(modifier)
-	print("[AllResetQuality] Applied RESET to %d bag tiles" % TileBag.available_tiles.size())
+	print("[AllResetQuality] Applied RESET to %d bag tiles" % TileBag.tiles_remaining())

--- a/scripts/domain/qualities/all_reset_quality.gd
+++ b/scripts/domain/qualities/all_reset_quality.gd
@@ -1,0 +1,46 @@
+extends RunQuality
+class_name AllResetQuality
+
+## AllResetQuality: Applies RESET/PER_ROUND modifier to every bag tile at round start.
+## Bundled by CursedDeck; NOT registered in QualityRegistry (not shown in UI quality list).
+##
+## on_round_started:
+##   Precondition : TileBag.available_tiles is populated.
+##   Postcondition: every tile in TileBag.available_tiles carries a RESET/PER_ROUND modifier.
+##   Invariant    : tile.add_modifier() replaces by type — no duplicates possible.
+
+# =============================================================================
+# IDENTITY
+# =============================================================================
+
+func get_quality_id() -> StringName:
+	return &"all_reset"
+
+
+func get_quality_name() -> String:
+	return "Cursed Tiles"
+
+
+func get_description() -> String:
+	return "All tiles carry the Reset modifier each round."
+
+# =============================================================================
+# LIFECYCLE
+# =============================================================================
+
+func on_round_started(_round_number: int) -> void:
+	_apply_reset_to_all_bag_tiles()
+
+# =============================================================================
+# PRIVATE
+# =============================================================================
+
+func _apply_reset_to_all_bag_tiles() -> void:
+	for tile in TileBag.available_tiles:
+		var modifier: ModifierInstance = ModifierRegistry.create_modifier(
+			ModifierTypes.Type.RESET,
+			ModifierTypes.Tier.BRONZE,
+			ModifierTypes.Lifetime.PER_ROUND
+		)
+		tile.add_modifier(modifier)
+	print("[AllResetQuality] Applied RESET to %d bag tiles" % TileBag.available_tiles.size())

--- a/scripts/domain/qualities/all_reset_quality.gd.uid
+++ b/scripts/domain/qualities/all_reset_quality.gd.uid
@@ -1,0 +1,1 @@
+uid://cfxkefda80e0u

--- a/scripts/domain/qualities/limited_time_with_increment_quality.gd
+++ b/scripts/domain/qualities/limited_time_with_increment_quality.gd
@@ -1,58 +1,32 @@
-extends RunQuality
+extends TimerQuality
 class_name LimitedTimeWithIncrementQuality
 
-## LimitedTimeWithIncrementQuality: Countdown timer that gains time on each play.
+## LimitedTimeWithIncrementQuality: Countdown timer that adds time on each play.
 
 const DEFAULT_TIME: float = 60.0
 const INCREMENT_PER_PLAY: float = 15.0
-
-var _time_remaining: float = DEFAULT_TIME
-var _is_active: bool = false
 
 
 func get_quality_id() -> StringName:
 	return &"limited_time_with_increment"
 
-
 func get_quality_name() -> String:
 	return "Time + Increment"
-
 
 func get_description() -> String:
 	return "%ds per round, +%ds per play." % [int(DEFAULT_TIME), int(INCREMENT_PER_PLAY)]
 
 
-func has_timer() -> bool:
-	return true
-
-
-func on_round_started(round_number: int) -> void:
+func on_round_started(_round_number: int) -> void:
 	_time_remaining = DEFAULT_TIME
 	_is_active = true
 
 
-func on_play_completed(plays_remaining: int) -> void:
+func on_play_completed(_plays_remaining: int) -> void:
 	if _is_active:
 		_time_remaining += INCREMENT_PER_PLAY
 		time_incremented.emit(INCREMENT_PER_PLAY)
 		time_updated.emit(_time_remaining)
-
-
-func on_round_ended(round_number: int, success: bool) -> void:
-	_is_active = false
-
-
-func on_process(delta: float) -> void:
-	if not _is_active:
-		return
-
-	_time_remaining -= delta
-	time_updated.emit(_time_remaining)
-
-	if _time_remaining <= 0.0:
-		_time_remaining = 0.0
-		_is_active = false
-		time_expired.emit()
 
 
 func to_dict() -> Dictionary:

--- a/scripts/domain/qualities/random_modifiers_quality.gd
+++ b/scripts/domain/qualities/random_modifiers_quality.gd
@@ -52,7 +52,7 @@ func on_round_started(_round_number: int) -> void:
 
 func _assign_modifiers_to_bag() -> void:
 	var count: int = 0
-	for tile in TileBag.available_tiles:
+	for tile in TileBag.get_available_tiles():
 		if randf() < MODIFIER_CHANCE:
 			var type: ModifierTypes.Type = _pick_weighted_type()
 			var tier: ModifierTypes.Tier = _pick_weighted_tier()
@@ -62,35 +62,27 @@ func _assign_modifiers_to_bag() -> void:
 			tile.add_modifier(modifier)
 			count += 1
 	print("[RandomModifiers] Assigned %d modifiers to %d available tiles" % [
-		count, TileBag.available_tiles.size()
+		count, TileBag.tiles_remaining()
 	])
 
 
-func _pick_weighted_type() -> ModifierTypes.Type:
+## Picks a random key from a weights dictionary {key: int_weight}.
+func _pick_weighted(weights: Dictionary) -> Variant:
 	var total: int = 0
-	for w in TYPE_WEIGHTS.values():
+	for w in weights.values():
 		total += w
-
 	var roll: int = randi() % total
 	var cumulative: int = 0
-	for type in TYPE_WEIGHTS.keys():
-		cumulative += TYPE_WEIGHTS[type]
+	for key in weights:
+		cumulative += weights[key]
 		if roll < cumulative:
-			return type
+			return key
+	return weights.keys()[0]
 
-	return ModifierTypes.Type.EXTRA
+
+func _pick_weighted_type() -> ModifierTypes.Type:
+	return _pick_weighted(TYPE_WEIGHTS)
 
 
 func _pick_weighted_tier() -> ModifierTypes.Tier:
-	var total: int = 0
-	for w in TIER_WEIGHTS.values():
-		total += w
-
-	var roll: int = randi() % total
-	var cumulative: int = 0
-	for tier in TIER_WEIGHTS.keys():
-		cumulative += TIER_WEIGHTS[tier]
-		if roll < cumulative:
-			return tier
-
-	return ModifierTypes.Tier.BRONZE
+	return _pick_weighted(TIER_WEIGHTS)

--- a/scripts/domain/qualities/time_attack_quality.gd
+++ b/scripts/domain/qualities/time_attack_quality.gd
@@ -1,55 +1,26 @@
-extends RunQuality
+extends TimerQuality
 class_name TimeAttackQuality
 
-## TimeAttackQuality: Each round has a countdown timer.
+## TimeAttackQuality: Each round has a fixed countdown timer.
 ## When time expires, the round is lost.
 
 const DEFAULT_TIME: float = 120.0
-
-var _time_remaining: float = DEFAULT_TIME
-var _is_active: bool = false
 
 
 func get_quality_id() -> StringName:
 	return &"time_attack"
 
-
 func get_quality_name() -> String:
 	return "Time Attack"
-
 
 func get_description() -> String:
 	return "Each round has a %d second time limit." % int(DEFAULT_TIME)
 
 
-func has_timer() -> bool:
-	return true
-
-
-func on_round_started(round_number: int) -> void:
+func on_round_started(_round_number: int) -> void:
 	_time_remaining = DEFAULT_TIME
 	_is_active = true
 
 
-func on_round_ended(round_number: int, success: bool) -> void:
-	_is_active = false
-
-
-func on_process(delta: float) -> void:
-	if not _is_active:
-		return
-
-	_time_remaining -= delta
-	time_updated.emit(_time_remaining)
-
-	if _time_remaining <= 0.0:
-		_time_remaining = 0.0
-		_is_active = false
-		time_expired.emit()
-
-
 func to_dict() -> Dictionary:
-	return {
-		"quality_id": get_quality_id(),
-		"default_time": DEFAULT_TIME,
-	}
+	return {"quality_id": get_quality_id(), "default_time": DEFAULT_TIME}

--- a/scripts/domain/qualities/timer_quality.gd
+++ b/scripts/domain/qualities/timer_quality.gd
@@ -1,0 +1,27 @@
+class_name TimerQuality
+extends RunQuality
+
+## Base class for RunQuality types that implement a countdown timer.
+## Subclasses set _time_remaining and _is_active in on_round_started().
+## The shared countdown + emission logic lives here.
+
+var _time_remaining: float = 0.0
+var _is_active: bool = false
+
+
+func has_timer() -> bool:
+	return true
+
+
+func on_round_ended(_round_number: int, _success: bool) -> void:
+	_is_active = false
+
+
+func on_process(delta: float) -> void:
+	if not _is_active:
+		return
+	_time_remaining = maxf(0.0, _time_remaining - delta)
+	time_updated.emit(_time_remaining)
+	if _time_remaining <= 0.0:
+		_is_active = false
+		time_expired.emit()

--- a/scripts/domain/qualities/timer_quality.gd.uid
+++ b/scripts/domain/qualities/timer_quality.gd.uid
@@ -1,0 +1,1 @@
+uid://dgh08tk8tgi0i

--- a/scripts/domain/run_builder.gd
+++ b/scripts/domain/run_builder.gd
@@ -96,8 +96,14 @@ func build() -> Run:
 	run.hand_size = _hand_size if _hand_size > 0 else run.progression_config.default_hand_size
 	run.plays_per_round = _plays_per_round if _plays_per_round > 0 else run.progression_config.default_plays_per_round
 
-	# Transfer qualities to the Run (builder should not be reused after build)
+	# Transfer qualities and reset all builder state so build() is safe to call again.
+	## Postcondition: every field returns to its sentinel/null value after build().
 	run.qualities = _qualities.duplicate()
+	_bag_config = null
+	_deck = null
+	_hand_size = -1
+	_plays_per_round = -1
+	_progression_config = null
 	_qualities.clear()
 
 	return run

--- a/scripts/domain/run_builder.gd
+++ b/scripts/domain/run_builder.gd
@@ -9,6 +9,7 @@ class_name RunBuilder
 # =============================================================================
 
 var _bag_config: BagDistribution = null
+var _deck: DeckDefinition = null
 var _hand_size: int = -1
 var _plays_per_round: int = -1
 var _progression_config: ProgressionConfig = null
@@ -20,6 +21,15 @@ var _qualities: Array[RunQuality] = []
 
 func set_bag(bag: BagDistribution) -> RunBuilder:
 	_bag_config = bag
+	return self
+
+
+## set_deck: Selects a deck for this run.
+## Postcondition: build() uses deck.create_distribution() as bag_config.
+## Postcondition: if deck.create_bundled_quality() != null, quality is added to run.qualities.
+## Invariant    : deck takes precedence over set_bag() when both are called.
+func set_deck(deck: DeckDefinition) -> RunBuilder:
+	_deck = deck
 	return self
 
 
@@ -62,7 +72,12 @@ func build() -> Run:
 	var run := Run.new()
 
 	# Apply defaults for missing fields
-	if _bag_config:
+	if _deck:
+		run.bag_config = _deck.create_distribution()
+		var bundled := _deck.create_bundled_quality()
+		if bundled != null:
+			add_quality(bundled)
+	elif _bag_config:
 		run.bag_config = _bag_config
 	else:
 		var default_bag := load("res://Data/BagDistribution/bag_default.tres") as BagDistribution

--- a/scripts/util/signal_tracker.gd
+++ b/scripts/util/signal_tracker.gd
@@ -1,0 +1,21 @@
+class_name SignalTracker
+extends RefCounted
+
+## Tracks signal connections and disconnects all at once.
+## Replaces ad-hoc _connections arrays and _safe_connect/_disconnect_all patterns.
+
+var _connections: Array[Dictionary] = []
+
+
+## Connects sig to fn and records the connection for later cleanup.
+func track(sig: Signal, fn: Callable) -> void:
+	sig.connect(fn)
+	_connections.append({s = sig, f = fn})
+
+
+## Disconnects all tracked connections and clears the list.
+func disconnect_all() -> void:
+	for c in _connections:
+		if c.s.is_connected(c.f):
+			c.s.disconnect(c.f)
+	_connections.clear()

--- a/scripts/util/signal_tracker.gd.uid
+++ b/scripts/util/signal_tracker.gd.uid
@@ -1,0 +1,1 @@
+uid://b3aol2aixyaro


### PR DESCRIPTION
This pull request introduces the deck selection feature to Wordatro, adding a new domain concept for decks, integrating deck selection into the run setup UI, and updating run initialization logic. It also improves signal connection/disconnection robustness and adds documentation for both the deck feature and animation systems. The changes are grouped below by theme.

### Deck Feature Implementation

* Added new deck domain model: `DeckDefinition` base class, concrete decks (`StandardDeck`, `EqualDeck`, `CursedDeck`), and `DeckRegistry` static factory for deck management.
* Created new bag distribution data file `Data/BagDistribution/bag_equal.tres` for the Equal deck (26 tiles, one of each letter).
* Integrated deck selection into run setup UI: new deck selector section in `run_setup_popup.gd`, dynamic population from `DeckRegistry`, and run builder logic updated to use selected deck and bundled quality. [[1]](diffhunk://#diff-59dd0117026b306dcf19fdfe9f5da8a5fd8c0b36b897bddac057cd7521dc328dR21-R32) [[2]](diffhunk://#diff-59dd0117026b306dcf19fdfe9f5da8a5fd8c0b36b897bddac057cd7521dc328dR41) [[3]](diffhunk://#diff-59dd0117026b306dcf19fdfe9f5da8a5fd8c0b36b897bddac057cd7521dc328dR69-R118) [[4]](diffhunk://#diff-59dd0117026b306dcf19fdfe9f5da8a5fd8c0b36b897bddac057cd7521dc328dL108-R164) [[5]](diffhunk://#diff-0835e24aa97f79bd373e001d38602f40601ac0afebff6644cb7652f1fd629ec7R1-R188)

### Run Initialization and Signal Handling

* Updated run initialization and reset logic to ensure debug flags are reset and no state bleeds between runs; improved signal disconnection logic in `run_manager.gd` and `main_hud.gd` with guards for freed objects and clearer logging. [[1]](diffhunk://#diff-020abdb0afa8140c055e50a6e6ff178901941f375cedeecbea87ff06294f49b5R53) [[2]](diffhunk://#diff-020abdb0afa8140c055e50a6e6ff178901941f375cedeecbea87ff06294f49b5R67) [[3]](diffhunk://#diff-020abdb0afa8140c055e50a6e6ff178901941f375cedeecbea87ff06294f49b5R116-R124) [[4]](diffhunk://#diff-020abdb0afa8140c055e50a6e6ff178901941f375cedeecbea87ff06294f49b5R188-R199) [[5]](diffhunk://#diff-e7c50655e332e9216306413ae119229c45ebe15fcd789e84175a8e8109b19fbdR156-R176)

### Documentation

* Added detailed feature design document for decks (`2026-02-21-decks-design.md`) and updated documentation directory structure and conventions. [[1]](diffhunk://#diff-0835e24aa97f79bd373e001d38602f40601ac0afebff6644cb7652f1fd629ec7R1-R188) [[2]](diffhunk://#diff-18b60c22b197bcd3ce70574e4b9c49ff03d166f3f39c6ac8fd75a4b7c5bc8947R1-R27) [[3]](diffhunk://#diff-285d2f9abe957ea78f1af641b99b7422ef305425f09c2b255036df7ab60c1416R1-R48)
* Added animation system documentation for spin tile animation, describing architecture, patterns, and conventions.

### Bash Command Allowlist

* Updated `.claude/settings.local.json` to allow additional Bash commands (`cd`, `cat`, `py`) and removed unused tile distribution manipulation commands. [[1]](diffhunk://#diff-fca16cae5b0e32edfa6b55eaa32a98ffbf4a0c7d885fb585785fc83b6ea2d9c3L6-L7) [[2]](diffhunk://#diff-fca16cae5b0e32edfa6b55eaa32a98ffbf4a0c7d885fb585785fc83b6ea2d9c3L16-R17)

---

**References:**  
[[1]](diffhunk://#diff-0835e24aa97f79bd373e001d38602f40601ac0afebff6644cb7652f1fd629ec7R1-R188) [[2]](diffhunk://#diff-39cd29494116ddeeeeda113f25aa15cd429b4c8cc249409945660f7ac59d2c78R1-R35) [[3]](diffhunk://#diff-59dd0117026b306dcf19fdfe9f5da8a5fd8c0b36b897bddac057cd7521dc328dR21-R32) [[4]](diffhunk://#diff-59dd0117026b306dcf19fdfe9f5da8a5fd8c0b36b897bddac057cd7521dc328dR41) [[5]](diffhunk://#diff-59dd0117026b306dcf19fdfe9f5da8a5fd8c0b36b897bddac057cd7521dc328dR69-R118) [[6]](diffhunk://#diff-59dd0117026b306dcf19fdfe9f5da8a5fd8c0b36b897bddac057cd7521dc328dL108-R164) [[7]](diffhunk://#diff-020abdb0afa8140c055e50a6e6ff178901941f375cedeecbea87ff06294f49b5R53) [[8]](diffhunk://#diff-020abdb0afa8140c055e50a6e6ff178901941f375cedeecbea87ff06294f49b5R67) [[9]](diffhunk://#diff-020abdb0afa8140c055e50a6e6ff178901941f375cedeecbea87ff06294f49b5R116-R124) [[10]](diffhunk://#diff-020abdb0afa8140c055e50a6e6ff178901941f375cedeecbea87ff06294f49b5R188-R199) [[11]](diffhunk://#diff-e7c50655e332e9216306413ae119229c45ebe15fcd789e84175a8e8109b19fbdR156-R176) [[12]](diffhunk://#diff-18b60c22b197bcd3ce70574e4b9c49ff03d166f3f39c6ac8fd75a4b7c5bc8947R1-R27) [[13]](diffhunk://#diff-285d2f9abe957ea78f1af641b99b7422ef305425f09c2b255036df7ab60c1416R1-R48) [[14]](diffhunk://#diff-3096f183864b48ce2368ee1629a49233c91644fdbea582529c6fbb2b7ed3fea0R1-R82) [[15]](diffhunk://#diff-fca16cae5b0e32edfa6b55eaa32a98ffbf4a0c7d885fb585785fc83b6ea2d9c3L6-L7) [[16]](diffhunk://#diff-fca16cae5b0e32edfa6b55eaa32a98ffbf4a0c7d885fb585785fc83b6ea2d9c3L16-R17)